### PR TITLE
 fix/refactor/test: lift pass limitations, expand fuzz coverage, and add Apple GOT hook detection 

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,4 @@ Features that were not implemented in Phase 4 and are candidates for future work
 | 4.8.9 | ML/heuristic-based protection target inference | Low | Use static features (cyclomatic complexity, symbol names, call graph centrality) to recommend which functions to protect |
 | 4.8.10 | Machine code / backend-level obfuscation | Low | Apply obfuscation at the assembler / MachineFunction level (after instruction selection) for deeper resistance to IR-level static analysis |
 | — | MSVC ABI support in VTableProtection | Med | Handle `??_7` / `??_R` MSVC naming conventions in addition to Itanium `_ZTV`/`_ZTS`/`_ZTI`; required for Windows target support |
-| — | Partial pass application for EH functions | Med | BBR, PE, and MVO currently skip entire functions that contain exception handling; apply passes to non-EH blocks only instead of bailing out |
-| — | VMObfuscation: widen jump offset to uint32 | Low | Bytecode jump targets are capped at uint16_t (64 KB); large functions silently get NOP'd. Widening to uint32 removes this hard limit |
 | — | Regression corpus expansion | High | Only one entry in tests/regression/corpus/; add .ll test cases covering EH, PHI-heavy, vararg, empty, and large functions for each pass |
-| — | FunctionSplit: allow call-containing blocks | Low | Blocks with simple leaf calls (no indirect, no EH) are unconditionally skipped; selectively allow noinline-safe calls to increase extraction rate |

--- a/include/kagura/VM.h
+++ b/include/kagura/VM.h
@@ -68,9 +68,9 @@ enum Opcode : uint8_t {
   OP_ICMP_SGE    = 0x39,
 
   // Control flow
-  OP_JMP         = 0x40, // unconditional jump (16-bit offset)
-  OP_JZ          = 0x41, // jump if top == 0
-  OP_JNZ         = 0x42, // jump if top != 0
+  OP_JMP         = 0x40, // unconditional jump (32-bit offset)
+  OP_JZ          = 0x41, // jump if top == 0 (32-bit offset)
+  OP_JNZ         = 0x42, // jump if top != 0 (32-bit offset)
   OP_CALL        = 0x43, // call native function pointer (from reg)
   OP_RET         = 0x44, // return top of stack (or void)
   OP_RET_VOID    = 0x45,
@@ -97,8 +97,8 @@ enum Opcode : uint8_t {
 
 // Maximum number of virtual registers per VM frame
 static constexpr unsigned kNumRegs   = 16;
-// Maximum bytecode size per function (bytes)
-static constexpr unsigned kMaxBCSize = 65536;
+// Maximum bytecode size per function (bytes) — limited only by uint32 address space
+static constexpr unsigned kMaxBCSize = 0xFFFFFFFFu;
 // VM stack depth limit
 static constexpr unsigned kStackSize = 256;
 

--- a/lib/Transforms/CFG/BasicBlockReordering.cpp
+++ b/lib/Transforms/CFG/BasicBlockReordering.cpp
@@ -21,7 +21,9 @@
 #include "kagura/Passes.h"
 #include "kagura/Utils.h"
 
+#include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Function.h"
+#include "llvm/IR/Instructions.h"
 
 #include <vector>
 
@@ -35,18 +37,29 @@ PreservedAnalyses BasicBlockReorderingPass::run(Function &F,
     return PreservedAnalyses::all();
   if (F.isDeclaration() || F.size() < 3)
     return PreservedAnalyses::all();
-  // 4.1.10: Moving EH landing-pad blocks away from their invoke predecessors
-  // produces invalid IR.  Skip the entire function if it uses exceptions.
-  if (hasExceptionHandling(F))
-    return PreservedAnalyses::all();
 
   PRNG &RNG = getModulePRNG();
 
-  // Collect non-entry blocks
+  // Collect non-entry, non-EH blocks.
+  // EH landing-pad blocks must stay adjacent to their invoke predecessors;
+  // moving them produces invalid IR.  We skip only those blocks, allowing
+  // the rest of the function to be reordered.
   std::vector<BasicBlock *> Blocks;
   Blocks.reserve(F.size() - 1);
   for (auto &BB : F) {
     if (&BB == &F.getEntryBlock())
+      continue;
+    if (isEHBlock(BB))
+      continue;
+    // Also skip blocks that are the unwind destination of an invoke —
+    // they must remain reachable from the invoke's unwind edge.
+    bool IsUnwindDest = false;
+    for (auto *Pred : predecessors(&BB)) {
+      if (auto *II = dyn_cast<InvokeInst>(Pred->getTerminator())) {
+        if (II->getUnwindDest() == &BB) { IsUnwindDest = true; break; }
+      }
+    }
+    if (IsUnwindDest)
       continue;
     Blocks.push_back(&BB);
   }

--- a/lib/Transforms/CFG/FunctionSplit.cpp
+++ b/lib/Transforms/CFG/FunctionSplit.cpp
@@ -68,11 +68,30 @@ namespace kagura {
 // Helpers
 // --------------------------------------------------------------------------
 
-/// Returns true if BB contains any call or invoke instruction.
-static bool hasCallInsts(const BasicBlock &BB) {
-  for (const auto &I : BB)
-    if (isa<CallInst>(I) || isa<InvokeInst>(I))
-      return true;
+/// Returns true if a call instruction is safe to extract into a helper:
+///   - Direct call to a known function (not indirect)
+///   - Not an invoke (no EH edge)
+///   - Not a call to an intrinsic (they may have special semantics / sideband
+///     effects that break when moved to a different function frame)
+///   - Not a variadic call (ABI complexity)
+static bool isLeafSafeCall(const CallInst &CI) {
+  if (CI.isIndirectCall()) return false;
+  Function *Callee = CI.getCalledFunction();
+  if (!Callee) return false;
+  if (Callee->isIntrinsic()) return false;
+  if (Callee->isVarArg()) return false;
+  return true;
+}
+
+/// Returns true if BB contains any instruction that is unsafe to extract:
+///   - InvokeInst (EH edge into landing pad)
+///   - Unsafe CallInst (indirect, intrinsic, vararg)
+static bool hasUnsafeCallInsts(const BasicBlock &BB) {
+  for (const auto &I : BB) {
+    if (isa<InvokeInst>(I)) return true;
+    if (const auto *CI = dyn_cast<CallInst>(&I))
+      if (!isLeafSafeCall(*CI)) return true;
+  }
   return false;
 }
 
@@ -141,8 +160,9 @@ static bool extractBlock(BasicBlock *BB, unsigned Index, PRNG &RNG) {
   if (isa<PHINode>(BB->front()))
     return false;
 
-  // Skip if the block contains calls (ABI complexity).
-  if (hasCallInsts(*BB))
+  // Skip if the block contains unsafe calls (invoke, indirect, intrinsic, vararg).
+  // Simple direct calls to non-intrinsic functions are safe to extract.
+  if (hasUnsafeCallInsts(*BB))
     return false;
 
   // Skip exit blocks (return / unreachable).

--- a/lib/Transforms/Data/MemoryValueObfuscation.cpp
+++ b/lib/Transforms/Data/MemoryValueObfuscation.cpp
@@ -85,8 +85,9 @@ PreservedAnalyses MemoryValueObfuscationPass::run(Function &F,
     return PreservedAnalyses::all();
   if (!shouldObfuscate(F, "mvo", true))
     return PreservedAnalyses::all();
-  if (hasExceptionHandling(F))
-    return PreservedAnalyses::all();
+  // EH functions are allowed: allocas in non-EH blocks are safe to transform.
+  // The allocaEscapes() check already rejects any alloca whose address is
+  // passed to an invoke or otherwise escapes.
 
   PRNG &RNG    = getModulePRNG();
   bool Changed = false;

--- a/lib/Transforms/Data/PointerEncryption.cpp
+++ b/lib/Transforms/Data/PointerEncryption.cpp
@@ -69,8 +69,9 @@ PreservedAnalyses PointerEncryptionPass::run(Function &F,
     return PreservedAnalyses::all();
   if (!shouldObfuscate(F, "pe", true))
     return PreservedAnalyses::all();
-  if (hasExceptionHandling(F))
-    return PreservedAnalyses::all();
+  // EH functions are allowed: the pointerAllocaEscapes() check already rejects
+  // any alloca whose address flows into an invoke or otherwise escapes the
+  // function, so non-EH allocas are safe to transform.
 
   LLVMContext &Ctx = F.getContext();
   auto *I64Ty  = Type::getInt64Ty(Ctx);

--- a/lib/Transforms/Platform/VMObfuscation.cpp
+++ b/lib/Transforms/Platform/VMObfuscation.cpp
@@ -76,18 +76,20 @@ public:
     }
   }
 
-  // Reserve a 16-bit jump target slot; returns offset of the slot
+  // Reserve a 32-bit jump target slot; returns offset of the slot
   uint32_t emitJmpPlaceholder(uint8_t jmpOp) {
     emit8(jmpOp);
     uint32_t off = BC.size();
-    emit16(0xFFFF); // placeholder
+    emit32(0xFFFFFFFF); // placeholder
     return off;
   }
 
   // Patch a previously reserved jump target
-  void patchJmp(uint32_t slotOffset, uint16_t target) {
-    BC[slotOffset]     = target & 0xFF;
-    BC[slotOffset + 1] = (target >> 8) & 0xFF;
+  void patchJmp(uint32_t slotOffset, uint32_t target) {
+    BC[slotOffset]     =  target        & 0xFF;
+    BC[slotOffset + 1] = (target >>  8) & 0xFF;
+    BC[slotOffset + 2] = (target >> 16) & 0xFF;
+    BC[slotOffset + 3] = (target >> 24) & 0xFF;
   }
 
   uint32_t size() const { return (uint32_t)BC.size(); }
@@ -207,7 +209,7 @@ static std::vector<uint8_t> virtualize(Function &F) {
 
   // Map basic blocks to bytecode offsets (two-pass: first collect, then patch)
   std::map<BasicBlock *, uint32_t> BBOffset;
-  std::vector<std::pair<uint32_t, BasicBlock *>> JmpPatches;
+  std::vector<std::pair<uint32_t, BasicBlock *>> JmpPatches; // {slot_offset, target_BB}
 
   // First pass: emit bytecode, record block offsets, leave jumps as placeholders
   for (auto &BB : F) {
@@ -320,7 +322,7 @@ static std::vector<uint8_t> virtualize(Function &F) {
   for (auto &[Slot, BB] : JmpPatches) {
     auto It = BBOffset.find(BB);
     if (It != BBOffset.end())
-      E.patchJmp(Slot, (uint16_t)It->second);
+      E.patchJmp(Slot, It->second);
   }
 
   return E.BC;

--- a/runtime/core/vm_interpreter.c
+++ b/runtime/core/vm_interpreter.c
@@ -192,17 +192,17 @@ uint64_t kagura_vm_execute(const uint8_t *bytecode, uint32_t bc_size,
 
         /* ── Control flow ──────────────────────── */
         case OP_JMP: {
-            uint16_t off = bc_u16(&f);
+            uint32_t off = bc_u32(&f);
             f.pc = off;
             break;
         }
         case OP_JZ: {
-            uint16_t off = bc_u16(&f);
+            uint32_t off = bc_u32(&f);
             if (vm_pop(&f) == 0) f.pc = off;
             break;
         }
         case OP_JNZ: {
-            uint16_t off = bc_u16(&f);
+            uint32_t off = bc_u32(&f);
             if (vm_pop(&f) != 0) f.pc = off;
             break;
         }


### PR DESCRIPTION
 ## Summary                                                

  This PR collects a set of bug fixes, robustness improvements, and test
  coverage additions across the obfuscation passes and runtime layer. No
  new features are introduced — the focus is on lifting known limitations
  and hardening the existing implementation.

  ---

  ### Pass fixes

  **FunctionSplitPass — PHI node successor handling** (`26f2a29`)
  Blocks whose successor started with PHI nodes were silently skipped.
  The pass now proceeds with extraction and repairs stale PHI incoming
  values (whose defining instructions were moved to the helper) by
  substituting `UndefValue`.
                                                                                             
  **FunctionSplitPass — allow safe direct calls** (`04d68d4`)
  The blanket `hasCallInsts()` guard is replaced with                                        
  `hasUnsafeCallInsts()`, which permits direct calls to non-intrinsic,                       
  non-vararg, non-indirect functions. `InvokeInst` and any call failing
  `isLeafSafeCall()` are still rejected. Increases the number of                             
  extractable blocks in call-heavy functions without ABI or EH risk.

  **BBR / MVO / PE — apply to EH functions at block granularity** (`250a66c`)
  All three passes previously bailed out on any function containing
  exception handling. Now:
  - `BasicBlockReorderingPass`: skips EH landing-pad blocks and invoke
    unwind destinations only; all other blocks remain eligible.
  - `MemoryValueObfuscationPass` / `PointerEncryptionPass`: removes the
    function-level EH guard; the existing `allocaEscapes()` checks
    already reject allocas that flow into invokes.                                           
   
  **VMObfuscationPass — widen jump offsets to uint32** (`a598ddb`)                           
  `JMP` / `JZ` / `JNZ` bytecode offsets were encoded as `uint16_t`,
  silently capping virtualizable functions at 64 KB of bytecode and                          
  emitting `NOP` for any block beyond that limit. Widened to `uint32_t`
  throughout: `VM.h`, `BytecodeEmitter`, `JmpPatches`, and                                   
  `vm_interpreter.c`.                                       

  ---

  ### Runtime                                                                                
   
  **GOT hook detection on Apple platforms** (`87eaebf`)                                      
  `kagura_check_got_hooks()` returned `0` on all non-Linux platforms.
  Now implements a Mach-O segment walk via `_dyld_image_count()` /
  `_dyld_get_image_header()` scanning `S_LAZY_SYMBOL_POINTERS` and
  `S_NON_LAZY_SYMBOL_POINTERS` sections for GOT entries that point
  outside all known loaded images — the signature of a fishhook-style
  redirect used by Frida and similar frameworks. Covers macOS and
  jailbroken iOS (32-bit and 64-bit).

  ---

  ### Refactor

  **StringEncryptionPass** (`4d0c117`)
  Replace `std::find` / iterator comparison in `collectEncryptionTargets`
  with `llvm::is_contained`.                                                                 
   
  ---                                                                                        
                                                            
  ### Tests

  **6 new libFuzzer targets** (`4c5d86d`)
  Fuzz coverage expanded from 4 passes to 10 by adding targets for
  `MemoryValueObfuscationPass`, `PointerEncryptionPass`,
  `BasicBlockReorderingPass`, `VTableProtectionPass`,
  `FunctionSplitPass`, and `VMObfuscationPass`. Each target parses
  arbitrary bytes as LLVM IR, runs the respective pass, and asserts
  module validity via `verifyModule()`.

  ---

  ## Test plan
  - [x] Build with `KAGURA_BUILD_FUZZ=ON` — confirm all 10 fuzz targets compile
  - [x] Run new fuzz targets against `tests/regression/corpus/`
  - [x] Verify `FunctionSplitPass` on IR with PHI-bearing successors and direct
  call-containing blocks
  - [x] Confirm BBR/MVO/PE produce valid IR on EH-containing functions (`llvm-verify`)
  - [x] Confirm VM bytecode roundtrip is correct for functions > 64 KB of bytecode
  - [x] On macOS, confirm `kagura_check_got_hooks()` returns `0` clean and `1` after a
  fishhook-style patch

✻ Churned for 1m 14s         