### PR TITLE
feat(bcf): diversify opaque predicates with 7 MBA variants

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,3 +12,11 @@ Features that were not implemented in Phase 4 and are candidates for future work
 | 4.8.10 | Machine code / backend-level obfuscation | Low | Apply obfuscation at the assembler / MachineFunction level (after instruction selection) for deeper resistance to IR-level static analysis |
 | — | MSVC ABI support in VTableProtection | Med | Handle `??_7` / `??_R` MSVC naming conventions in addition to Itanium `_ZTV`/`_ZTS`/`_ZTI`; required for Windows target support |
 | — | Regression corpus expansion | High | Only one entry in tests/regression/corpus/; add .ll test cases covering EH, PHI-heavy, vararg, empty, and large functions for each pass |
+| A.1 | Windows/MSVC build support | High | CMake skeleton exists but MSVC ABI IR is untested end-to-end; required for enterprise Windows targets |
+| A.2 | Swift / Kotlin Native string encryption | High | StringEncryption currently skips Swift and Kotlin Native constant strings on iOS/Android |
+| ~~A.3~~ | ~~BCF opaque predicate diversification~~ | ~~High~~ | ~~Implemented: 7 variants (OR/XOR/ADD complement, consecutive-int products, OR-odd, bit round-trip), selected at random per injection site~~ |
+| B.1 | Decompiler resistance scoring | Medium | Automate Binary Ninja / Ghidra analysis to produce a quantitative resilience score; feed back into AutoSelectPass |
+| B.2 | CallIndirection hot-path cache | Medium | Resolution happens on every call; a per-site cache would reduce overhead on hot paths |
+| B.3 | Deterministic obfuscation sessions | Medium | Given the same seed key and IR, produce a bit-identical output binary to ensure CI reproducibility |
+| C.1 | WebAssembly backend support | Low | Unity WebGL and other Wasm targets are growing; needs a Wasm-aware pass pipeline |
+| C.2 | Automated MBA expression generation | Low | Current SUB uses fixed patterns; auto-generate Z3-verified equivalent expressions for richer MBA substitution |

--- a/lib/Transforms/CFG/BogusControlFlow.cpp
+++ b/lib/Transforms/CFG/BogusControlFlow.cpp
@@ -4,11 +4,16 @@
 // but difficult to evaluate statically or symbolically.
 //
 // Unlike DeClang (which uses FCMP_TRUE — trivially solved by any solver),
-// we use Mixed Boolean-Arithmetic (MBA) predicates:
+// we use Mixed Boolean-Arithmetic (MBA) predicates.  Multiple variants are
+// implemented and selected at random to defeat static pattern matching:
 //
-//   (x | ~x) == -1          (always true for any x)
-//   (x & ~x) == 0           (always true for any x)
-//   x*(x+1) % 2 == 0        (product of consecutive ints is always even)
+//   (x | ~x) == -1           (always true — OR complement)
+//   (x ^ ~x) == -1           (always true — XOR complement)
+//   (x + ~x) == -1           (always true — ADD complement, i.e. x + (-x-1))
+//   (x * (x+1)) & 1 == 0     (always true — product of consecutive ints is even)
+//   ((x | 1) & 1) == 1       (always true — any number OR 1 is odd)
+//   (x * (x-1)) & 1 == 0     (always true — product of consecutive ints is even)
+//   ((x >> 1) << 1) | (x & 1) == x  (always true — bit round-trip identity)
 //
 // The "true" branch executes the original block; the "false" branch contains
 // a semantically equivalent but junk-filled copy (never actually taken).
@@ -32,44 +37,95 @@ namespace kagura {
 
 // ---- Opaque predicate builders ----
 
-// Returns a Value* that is always true (i1 1) regardless of runtime values,
-// but is expressed as a non-trivial MBA expression to resist symbolic solvers.
-// Uses an existing integer value from the function as the "variable" so that
-// solvers cannot immediately constant-fold it.
-static Value *buildMBAOpaqueTrue(IRBuilder<> &B, Value *X) {
-  LLVMContext &Ctx = B.getContext();
-  auto *I32 = Type::getInt32Ty(Ctx);
-
-  // Cast X to i32 if needed
-  Value *V = X;
-  if (V->getType() != I32) {
-    if (V->getType()->isIntegerTy())
-      V = B.CreateZExtOrTrunc(V, I32);
-    else
-      V = ConstantInt::get(I32, 0x12345678);
-  }
-
-  // Predicate: (V | ~V) == -1  (always true by De Morgan)
-  auto *NotV   = B.CreateNot(V, "bcf.notv");
-  auto *OrV    = B.CreateOr(V, NotV, "bcf.or");
-  auto *MinusOne = ConstantInt::get(I32, ~0U);
-  return B.CreateICmpEQ(OrV, MinusOne, "bcf.pred");
+// Normalise X to i32 for predicate construction.
+static Value *toI32(IRBuilder<> &B, Value *X, uint32_t FallbackConst) {
+  auto *I32 = Type::getInt32Ty(B.getContext());
+  if (X->getType() == I32)
+    return X;
+  if (X->getType()->isIntegerTy())
+    return B.CreateZExtOrTrunc(X, I32, "bcf.cast");
+  return ConstantInt::get(I32, FallbackConst);
 }
 
-// Returns a Value* that is always false: (V & ~V) == 1 (never true)
-static Value *buildMBAOpaqueFalse(IRBuilder<> &B, Value *X) {
-  LLVMContext &Ctx = B.getContext();
-  auto *I32 = Type::getInt32Ty(Ctx);
-  Value *V = X;
-  if (V->getType() != I32) {
-    if (V->getType()->isIntegerTy())
-      V = B.CreateZExtOrTrunc(V, I32);
-    else
-      V = ConstantInt::get(I32, 0xDEADBEEF);
-  }
-  auto *NotV = B.CreateNot(V);
-  auto *AndV = B.CreateAnd(V, NotV);
-  return B.CreateICmpNE(AndV, ConstantInt::get(I32, 0));
+// Predicate 0: (V | ~V) == -1   (OR complement — always true)
+static Value *buildPred0(IRBuilder<> &B, Value *X) {
+  Value *V    = toI32(B, X, 0x12345678);
+  auto *I32   = Type::getInt32Ty(B.getContext());
+  Value *NotV = B.CreateNot(V, "bcf.notv");
+  Value *OrV  = B.CreateOr(V, NotV, "bcf.or");
+  return B.CreateICmpEQ(OrV, ConstantInt::get(I32, ~0U), "bcf.pred");
+}
+
+// Predicate 1: (V ^ ~V) == -1   (XOR complement — always true)
+static Value *buildPred1(IRBuilder<> &B, Value *X) {
+  Value *V    = toI32(B, X, 0xABCDEF01);
+  auto *I32   = Type::getInt32Ty(B.getContext());
+  Value *NotV = B.CreateNot(V, "bcf.notv");
+  Value *XorV = B.CreateXor(V, NotV, "bcf.xor");
+  return B.CreateICmpEQ(XorV, ConstantInt::get(I32, ~0U), "bcf.pred");
+}
+
+// Predicate 2: (V + ~V) == -1   (ADD complement: V + (-V-1) == -1 always)
+static Value *buildPred2(IRBuilder<> &B, Value *X) {
+  Value *V    = toI32(B, X, 0xFEDCBA98);
+  auto *I32   = Type::getInt32Ty(B.getContext());
+  Value *NotV = B.CreateNot(V, "bcf.notv");
+  Value *Sum  = B.CreateAdd(V, NotV, "bcf.add");
+  return B.CreateICmpEQ(Sum, ConstantInt::get(I32, ~0U), "bcf.pred");
+}
+
+// Predicate 3: (V * (V+1)) & 1 == 0   (product of consecutive ints is even)
+static Value *buildPred3(IRBuilder<> &B, Value *X) {
+  Value *V    = toI32(B, X, 0x13579BDF);
+  auto *I32   = Type::getInt32Ty(B.getContext());
+  Value *Vp1  = B.CreateAdd(V, ConstantInt::get(I32, 1), "bcf.vp1");
+  Value *Prod = B.CreateMul(V, Vp1, "bcf.mul");
+  Value *And1 = B.CreateAnd(Prod, ConstantInt::get(I32, 1), "bcf.and");
+  return B.CreateICmpEQ(And1, ConstantInt::get(I32, 0), "bcf.pred");
+}
+
+// Predicate 4: (V * (V-1)) & 1 == 0   (same: n*(n-1) is also always even)
+static Value *buildPred4(IRBuilder<> &B, Value *X) {
+  Value *V    = toI32(B, X, 0x2468ACE0);
+  auto *I32   = Type::getInt32Ty(B.getContext());
+  Value *Vm1  = B.CreateSub(V, ConstantInt::get(I32, 1), "bcf.vm1");
+  Value *Prod = B.CreateMul(V, Vm1, "bcf.mul");
+  Value *And1 = B.CreateAnd(Prod, ConstantInt::get(I32, 1), "bcf.and");
+  return B.CreateICmpEQ(And1, ConstantInt::get(I32, 0), "bcf.pred");
+}
+
+// Predicate 5: (V | 1) & 1 == 1   (OR with 1 is always odd)
+static Value *buildPred5(IRBuilder<> &B, Value *X) {
+  Value *V    = toI32(B, X, 0x11223344);
+  auto *I32   = Type::getInt32Ty(B.getContext());
+  Value *Or1  = B.CreateOr(V, ConstantInt::get(I32, 1), "bcf.or1");
+  Value *And1 = B.CreateAnd(Or1, ConstantInt::get(I32, 1), "bcf.and");
+  return B.CreateICmpEQ(And1, ConstantInt::get(I32, 1), "bcf.pred");
+}
+
+// Predicate 6: ((V >> 1) << 1) | (V & 1) == V   (bit round-trip identity)
+static Value *buildPred6(IRBuilder<> &B, Value *X) {
+  Value *V    = toI32(B, X, 0x55AA55AA);
+  auto *I32   = Type::getInt32Ty(B.getContext());
+  Value *Shr  = B.CreateLShr(V, ConstantInt::get(I32, 1), "bcf.shr");
+  Value *Shl  = B.CreateShl(Shr, ConstantInt::get(I32, 1), "bcf.shl");
+  Value *Lo   = B.CreateAnd(V, ConstantInt::get(I32, 1), "bcf.lo");
+  Value *Rec  = B.CreateOr(Shl, Lo, "bcf.rec");
+  return B.CreateICmpEQ(Rec, V, "bcf.pred");
+}
+
+using PredicateBuilder = Value *(*)(IRBuilder<> &, Value *);
+static constexpr PredicateBuilder kTruePredicates[] = {
+    buildPred0, buildPred1, buildPred2, buildPred3,
+    buildPred4, buildPred5, buildPred6,
+};
+static constexpr unsigned kNumTruePredicates =
+    sizeof(kTruePredicates) / sizeof(kTruePredicates[0]);
+
+// Select a predicate at random and build it.
+static Value *buildMBAOpaqueTrue(IRBuilder<> &B, Value *X, PRNG &RNG) {
+  unsigned Idx = static_cast<unsigned>(RNG.nextRange(0, kNumTruePredicates));
+  return kTruePredicates[Idx](B, X);
 }
 
 // Pick a "random" existing integer value from the block (first int SSA value).
@@ -107,7 +163,7 @@ static BasicBlock *makeBogusClone(BasicBlock *BB, Function *F) {
 }
 
 static bool obfuscateFunction(Function &F, uint32_t Probability,
-                               uint32_t Iterations, PRNG &RNG) {
+                              uint32_t Iterations, PRNG &RNG) {
   if (F.isDeclaration() || F.size() < 2)
     return false;
 
@@ -147,7 +203,7 @@ static bool obfuscateFunction(Function &F, uint32_t Probability,
       Instruction *OldTerm = BB->getTerminator();
       IRBuilder<> B(OldTerm);
       Value *X    = pickIntValue(BB);
-      Value *Cond = buildMBAOpaqueTrue(B, X);
+      Value *Cond = buildMBAOpaqueTrue(B, X, RNG);
       B.CreateCondBr(Cond, OrigTail, BogusBlock);
       OldTerm->eraseFromParent();
 


### PR DESCRIPTION
## Summary

- Extends `BogusControlFlow` from 1 hardcoded predicate to **7 distinct MBA variants**, selected at random per injection site via PRNG
- Adds `toI32()` normalisation helper to deduplicate type-cast logic across all predicates
- Removes the previously unused `buildMBAOpaqueFalse` function
- Marks A.3 complete in `TODO.md`

### Predicate variants

| # | Expression | Principle |
|---|-----------|-----------|
| 0 | `(V \| ~V) == -1` | OR complement (existing) |
| 1 | `(V ^ ~V) == -1` | XOR complement |
| 2 | `(V + ~V) == -1` | ADD complement |
| 3 | `(V * (V+1)) & 1 == 0` | Consecutive-int product (forward) |
| 4 | `(V * (V-1)) & 1 == 0` | Consecutive-int product (backward) |
| 5 | `(V \| 1) & 1 == 1` | OR-odd identity |
| 6 | `((V>>1)<<1)\|(V&1) == V` | Bit round-trip identity |

## Test plan

- [x] `cmake --build build --target KaguraObfuscator` — clean build, no warnings
- [x] `tests/lit/bogus-control-flow.ll` — FileCheck PASS
- [x] `cmake --build build --target check-kagura` — integration tests PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)