### PR TITLE
feat(wstr,vtp): Swift/Kotlin string encryption and MSVC VTP lit test (A.1, A.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,65 @@ jobs:
       - name: Test
         run: cd build && ctest --output-on-failure -j$(sysctl -n hw.logicalcpu)
 
+  # ---- A.1: Windows / MSVC build (Clang-CL + LLVM via winget/choco) -------
+  windows-msvc:
+    name: Build & Test (Windows LLVM ${{ matrix.llvm }})
+    runs-on: windows-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { llvm: "17" }
+          - { llvm: "19" }
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install LLVM ${{ matrix.llvm }} (winget)
+        shell: pwsh
+        run: |
+          # Try winget first (available on windows-latest since 2023-10)
+          $ver = "${{ matrix.llvm }}"
+          winget install --id LLVM.LLVM --version "$ver" `
+            --accept-source-agreements --accept-package-agreements `
+            --silent 2>$null
+          if ($LASTEXITCODE -ne 0) {
+            # Fallback: choco
+            choco install llvm --version "$ver" -y --no-progress
+          }
+          # Locate LLVM CMake dir and export to GITHUB_ENV
+          $llvmRoot = "C:\Program Files\LLVM"
+          if (-not (Test-Path $llvmRoot)) {
+            $llvmRoot = "C:\ProgramData\chocolatey\lib\llvm\tools\llvm"
+          }
+          echo "LLVM_PREFIX=$llvmRoot" >> $env:GITHUB_ENV
+
+      - name: Configure (Clang-CL)
+        shell: pwsh
+        run: |
+          $clang  = "$env:LLVM_PREFIX\bin\clang-cl.exe"
+          $clangxx= "$env:LLVM_PREFIX\bin\clang-cl.exe"
+          $llvmDir= "$env:LLVM_PREFIX\lib\cmake\llvm"
+          cmake -B build `
+            -G "Ninja" `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_C_COMPILER="$clang" `
+            -DCMAKE_CXX_COMPILER="$clangxx" `
+            -DLLVM_DIR="$llvmDir" `
+            -DKAGURA_BUILD_TESTS=ON `
+            -DKAGURA_BITCODE_TOOLS=OFF
+
+      - name: Build
+        shell: pwsh
+        run: cmake --build build
+
+      - name: Test
+        shell: pwsh
+        run: |
+          cd build
+          ctest --output-on-failure
+
   # ---- 4.7.4 NDK version matrix (Android cross-compile, Ubuntu) --------
   ndk-matrix:
     name: NDK ${{ matrix.ndk }} / LLVM ${{ matrix.llvm }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,32 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# ---- A.1: MSVC / Clang-CL compiler flags ----------------------------------
+if(MSVC)
+  # /utf-8          : source and execution charset both UTF-8
+  # /W3             : warning level 3 (matches clang -Wall)
+  # /WX-            : warnings are not errors (LLVM headers trigger some)
+  # /EHsc           : standard C++ exception handling (required by LLVM)
+  # /Zc:__cplusplus : make _cplusplus reflect the actual standard
+  # /wd4624 /wd4244 : suppress common LLVM-generated warnings on MSVC
+  add_compile_options(
+    /utf-8
+    /W3
+    /WX-
+    /EHsc
+    /Zc:__cplusplus
+    /wd4624
+    /wd4244
+  )
+  # Suppress MSVC's min/max macros that conflict with std::min/std::max
+  add_compile_definitions(NOMINMAX WIN32_LEAN_AND_MEAN)
+elseif(WIN32)
+  # Clang-CL or MinGW cross-compile targeting Windows
+  add_compile_options(-Wall -Wno-unused-parameter)
+  add_compile_definitions(NOMINMAX WIN32_LEAN_AND_MEAN)
+endif()
+# ---------------------------------------------------------------------------
+
 # ---- 4.6.8 Build cache support -------------------------------------------
 # Enable ccache / sccache if available. Set KAGURA_USE_CACHE=OFF to disable.
 option(KAGURA_USE_CACHE "Use compiler cache (ccache/sccache) if available" ON)

--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@ Features that were not implemented in Phase 4 and are candidates for future work
 | 4.8.10 | Machine code / backend-level obfuscation | Low | Apply obfuscation at the assembler / MachineFunction level (after instruction selection) for deeper resistance to IR-level static analysis |
 | — | MSVC ABI support in VTableProtection | Med | Handle `??_7` / `??_R` MSVC naming conventions in addition to Itanium `_ZTV`/`_ZTS`/`_ZTI`; required for Windows target support |
 | — | Regression corpus expansion | High | Only one entry in tests/regression/corpus/; add .ll test cases covering EH, PHI-heavy, vararg, empty, and large functions for each pass |
-| ~~A.1~~ | ~~Windows/MSVC build support~~ | ~~High~~ | ~~Implemented: MSVC ABI lit test (vtp-msvc.ll) added covering ??_7 vtable tagging and ??_R0 TypeDescriptor name encryption~~ |
+| ~~A.1~~ | ~~Windows/MSVC build support~~ | ~~High~~ | ~~Implemented: MSVC/Clang-CL CMake flags, Windows CI job (LLVM 17/19), runtime/windows/ stubs (anti_debug, integrity, tamper_response, device_key), vtp-msvc.ll lit test~~ |
 | ~~A.2~~ | ~~Swift / Kotlin Native string encryption~~ | ~~High~~ | ~~Implemented: WideStringEncryptionPass extended to detect and XOR-encrypt Swift ($s mangled) and Kotlin Native (.kotlin/kfun: prefix) string constants via module constructors (priority -1 for Swift, 0 for Kotlin)~~ |
 | ~~A.3~~ | ~~BCF opaque predicate diversification~~ | ~~High~~ | ~~Implemented: 7 variants (OR/XOR/ADD complement, consecutive-int products, OR-odd, bit round-trip), selected at random per injection site~~ |
 | B.1 | Decompiler resistance scoring | Medium | Automate Binary Ninja / Ghidra analysis to produce a quantitative resilience score; feed back into AutoSelectPass |

--- a/TODO.md
+++ b/TODO.md
@@ -10,8 +10,8 @@ Features that were not implemented in Phase 4 and are candidates for future work
 | 4.8.10 | Machine code / backend-level obfuscation | Low | Apply obfuscation at the assembler / MachineFunction level (after instruction selection) for deeper resistance to IR-level static analysis |
 | — | MSVC ABI support in VTableProtection | Med | Handle `??_7` / `??_R` MSVC naming conventions in addition to Itanium `_ZTV`/`_ZTS`/`_ZTI`; required for Windows target support |
 | — | Regression corpus expansion | High | Only one entry in tests/regression/corpus/; add .ll test cases covering EH, PHI-heavy, vararg, empty, and large functions for each pass |
-| A.1 | Windows/MSVC build support | High | CMake skeleton exists but MSVC ABI IR is untested end-to-end; required for enterprise Windows targets |
-| A.2 | Swift / Kotlin Native string encryption | High | StringEncryption currently skips Swift and Kotlin Native constant strings on iOS/Android |
+| ~~A.1~~ | ~~Windows/MSVC build support~~ | ~~High~~ | ~~Implemented: MSVC ABI lit test (vtp-msvc.ll) added covering ??_7 vtable tagging and ??_R0 TypeDescriptor name encryption~~ |
+| ~~A.2~~ | ~~Swift / Kotlin Native string encryption~~ | ~~High~~ | ~~Implemented: WideStringEncryptionPass extended to detect and XOR-encrypt Swift ($s mangled) and Kotlin Native (.kotlin/kfun: prefix) string constants via module constructors (priority -1 for Swift, 0 for Kotlin)~~ |
 | ~~A.3~~ | ~~BCF opaque predicate diversification~~ | ~~High~~ | ~~Implemented: 7 variants (OR/XOR/ADD complement, consecutive-int products, OR-odd, bit round-trip), selected at random per injection site~~ |
 | B.1 | Decompiler resistance scoring | Medium | Automate Binary Ninja / Ghidra analysis to produce a quantitative resilience score; feed back into AutoSelectPass |
 | B.2 | CallIndirection hot-path cache | Medium | Resolution happens on every call; a per-site cache would reduce overhead on hot paths |

--- a/lib/Transforms/Data/WideStringEncryption.cpp
+++ b/lib/Transforms/Data/WideStringEncryption.cpp
@@ -1,7 +1,7 @@
 //===-- WideStringEncryption.cpp - Wide / UTF-16 / CFString encryption ----===//
 //
-// 4.2.1: Extends string encryption coverage to three additional string types
-// that the narrow-char StringEncryption pass misses:
+// 4.2.1 / A.2: Extends string encryption coverage to five additional string
+// types that the narrow-char StringEncryption pass misses:
 //
 //   1. Wide character arrays (wchar_t / char16_t / char32_t)
 //      LLVM represents these as ConstantDataArray of i16 or i32.  Each
@@ -24,12 +24,26 @@
 //      backing i8 array using the same XOR scheme.  A module constructor
 //      decrypts all CFString backing buffers before ObjC code runs.
 //
+//   4. Swift string constant globals
+//      swiftc emits string literals as private/internal [N x i8] globals
+//      whose names are Swift-mangled (start with "$s" or contain ".str").
+//      We detect these by name pattern and apply the same XOR + module-
+//      constructor scheme.  A priority-(-1) ctor ensures decryption happens
+//      before Swift runtime initialisation.
+//
+//   5. Kotlin Native string constant globals
+//      kotlinc-native emits UTF-8 string literals as private/internal
+//      [N x i8] globals with Kotlin-specific mangling or section hints
+//      (names starting with "kfun:", ".kotlin_string_pool", or the
+//      kotlinx/kotlin namespace patterns in Itanium-style mangling).
+//      Same XOR + module-constructor scheme; priority 0.
+//
 // Pass key:   "kagura-wstr"
 // CLI flag:   -kagura-wstr
 //
 // Lazy-decrypt guards (4.2.4 style) are applied to wchar/UTF-16 strings.
-// CFString buffers are decrypted once in a module constructor to avoid
-// patching the ObjC runtime's internal string table.
+// CFString / Swift / Kotlin buffers are decrypted once in a module
+// constructor to avoid patching the runtime's internal string tables.
 //
 //===----------------------------------------------------------------------===//
 
@@ -60,7 +74,8 @@ namespace kagura {
 static bool isWideStringGlobal(const GlobalVariable &GV) {
   if (!GV.isConstant() || !GV.hasInitializer())
     return false;
-  if (GV.getName().starts_with("kagura_") || GV.getName().starts_with("llvm."))
+  if (GV.getName().starts_with("kagura_") || GV.getName().starts_with("llvm.") ||
+      GV.getName().starts_with("$kagura_"))
     return false;
   auto *CDA = dyn_cast<ConstantDataArray>(GV.getInitializer());
   if (!CDA)
@@ -77,6 +92,64 @@ static bool isWideStringGlobal(const GlobalVariable &GV) {
     }
   }
   return HasNonNull;
+}
+
+/// Returns true if GV looks like a Swift string literal constant emitted by
+/// swiftc.  Swift mangles globals with a "$s" prefix; string storage globals
+/// additionally carry ".str" or "Ss" (Swift.String) in their name.  We accept
+/// any private/internal [N x i8] global whose name starts with "$s" to catch
+/// the full range of Swift-generated string constants.
+static bool isSwiftStringGlobal(const GlobalVariable &GV) {
+  if (!GV.isConstant() || !GV.hasInitializer())
+    return false;
+  if (GV.getName().starts_with("kagura_") || GV.getName().starts_with("llvm."))
+    return false;
+  // Must be a byte array with printable content.
+  auto *CDA = dyn_cast<ConstantDataArray>(GV.getInitializer());
+  if (!CDA || !CDA->isString())
+    return false;
+  if (CDA->getAsString().size() < 2)
+    return false;
+  // Linkage guard: Swift string literals are always private or internal.
+  if (GV.getLinkage() != GlobalValue::PrivateLinkage &&
+      GV.getLinkage() != GlobalValue::InternalLinkage)
+    return false;
+  StringRef N = GV.getName();
+  // Swift mangled names start with "$s".
+  if (N.starts_with("$s"))
+    return true;
+  // swiftc also emits un-mangled ".str" helper globals in some IR modes.
+  if (N.contains(".str") && N.starts_with("_"))
+    return true;
+  return false;
+}
+
+/// Returns true if GV looks like a Kotlin Native string constant.
+/// kotlinc-native emits UTF-8 string storage as private [N x i8] globals.
+/// Identifiable patterns:
+///   - name starts with "kfun:" (Kotlin function-qualified name)
+///   - name starts with ".kotlin" (Kotlin internal section marker)
+///   - name contains "_kotlin_" (Kotlin stdlib symbol)
+///   - Itanium-mangled names containing "kotlin" namespace (N6kotlin)
+static bool isKotlinStringGlobal(const GlobalVariable &GV) {
+  if (!GV.isConstant() || !GV.hasInitializer())
+    return false;
+  if (GV.getName().starts_with("kagura_") || GV.getName().starts_with("llvm."))
+    return false;
+  auto *CDA = dyn_cast<ConstantDataArray>(GV.getInitializer());
+  if (!CDA || !CDA->isString())
+    return false;
+  if (CDA->getAsString().size() < 2)
+    return false;
+  if (GV.getLinkage() != GlobalValue::PrivateLinkage &&
+      GV.getLinkage() != GlobalValue::InternalLinkage)
+    return false;
+  StringRef N = GV.getName();
+  if (N.starts_with("kfun:") || N.starts_with(".kotlin"))
+    return true;
+  if (N.contains("_kotlin_") || N.contains("N6kotlin"))
+    return true;
+  return false;
 }
 
 /// Returns true if GV is a CFString struct (Apple __cfstring section).
@@ -215,6 +288,38 @@ static void buildCFStringDecryptCtor(
 }
 
 // ---------------------------------------------------------------------------
+// Swift / Kotlin string constructor injection
+// ---------------------------------------------------------------------------
+
+/// Build a single module constructor that calls all Swift or Kotlin string
+/// decrypt stubs in order.  Priority controls ordering relative to runtimes:
+///   Swift:  -1  (before Swift runtime init)
+///   Kotlin:  0  (same priority as CFString; before Kotlin runtime)
+static void buildRuntimeStringDecryptCtor(
+    Module &M,
+    const SmallVector<Function *, 8> &Stubs,
+    StringRef CtorName,
+    int Priority) {
+  if (Stubs.empty())
+    return;
+  LLVMContext &Ctx = M.getContext();
+  auto *VoidTy  = Type::getVoidTy(Ctx);
+  auto *CtorFTy = FunctionType::get(VoidTy, false);
+  auto *Ctor    = Function::Create(CtorFTy, Function::InternalLinkage,
+                                   CtorName, M);
+  Ctor->addFnAttr(Attribute::NoInline);
+  Ctor->addFnAttr(Attribute::NoUnwind);
+
+  auto *Entry = BasicBlock::Create(Ctx, "entry", Ctor);
+  IRBuilder<> B(Entry);
+  for (auto *Stub : Stubs)
+    B.CreateCall(Stub);
+  B.CreateRetVoid();
+
+  appendToGlobalCtors(M, Ctor, Priority);
+}
+
+// ---------------------------------------------------------------------------
 // Pass entry point
 // ---------------------------------------------------------------------------
 
@@ -263,6 +368,11 @@ PreservedAnalyses WideStringEncryptionPass::run(Module &M,
     GV->setConstant(false);
     GV->setInitializer(EncConst);
 
+    // Snapshot users BEFORE building the stub so that instructions inserted
+    // inside the decrypt stub (which also reference GV) are not processed
+    // by the lazy-guard loop below.
+    SmallVector<User *, 8> Users(GV->users());
+
     // 4.2.4: per-string flag
     auto *FlagGV = new GlobalVariable(M, Int8Ty, /*isConstant=*/false,
                                       GlobalValue::PrivateLinkage,
@@ -273,7 +383,6 @@ PreservedAnalyses WideStringEncryptionPass::run(Module &M,
     Function *Stub = buildWideDecryptStub(M, GV, N, ElemBits, Key, Suffix);
 
     // Inject lazy guard before every instruction that uses this global.
-    SmallVector<User *, 8> Users(GV->users());
     for (auto *U : Users) {
       auto *Inst = dyn_cast<Instruction>(U);
       if (!Inst)
@@ -346,6 +455,89 @@ PreservedAnalyses WideStringEncryptionPass::run(Module &M,
   }
 
   buildCFStringDecryptCtor(M, CFDecryptors);
+
+  // ---- Swift string constants ([N x i8] private globals, "$s" prefix) ------
+
+  SmallVector<Function *, 8> SwiftStubs;
+
+  for (auto &GV : M.globals()) {
+    if (!isSwiftStringGlobal(GV))
+      continue;
+    auto *CDA = dyn_cast<ConstantDataArray>(GV.getInitializer());
+    if (!CDA)
+      continue;
+    StringRef Raw = CDA->getAsString();
+    uint64_t Len  = Raw.size();
+
+    uint8_t Key[8];
+    uint64_t RandKey = RNG.next();
+    for (unsigned I = 0; I < 8; ++I)
+      Key[I] = static_cast<uint8_t>((RandKey >> (I * 8)) & 0xFF);
+
+    // Encrypt in-place.
+    std::vector<Constant *> EncBytes;
+    EncBytes.reserve(Len);
+    for (uint64_t I = 0; I < Len; ++I)
+      EncBytes.push_back(ConstantInt::get(Int8Ty,
+          static_cast<uint8_t>(Raw[I]) ^ Key[I % 8]));
+    auto *EncConst = ConstantArray::get(ArrayType::get(Int8Ty, Len), EncBytes);
+
+    const_cast<GlobalVariable &>(GV).setConstant(false);
+    const_cast<GlobalVariable &>(GV).setInitializer(EncConst);
+
+    std::string Suffix = std::to_string(RNG.next32());
+    Function *Stub = buildWideDecryptStub(
+        M, &const_cast<GlobalVariable &>(GV),
+        static_cast<unsigned>(Len), 8, Key, "swift_" + Suffix);
+    SwiftStubs.push_back(Stub);
+
+    Changed = true;
+  }
+
+  buildRuntimeStringDecryptCtor(M, SwiftStubs,
+                                 "kagura_swift_string_decrypt_ctor",
+                                 /*Priority=*/-1);
+
+  // ---- Kotlin Native string constants (private [N x i8], kotlin patterns) --
+
+  SmallVector<Function *, 8> KotlinStubs;
+
+  for (auto &GV : M.globals()) {
+    if (!isKotlinStringGlobal(GV))
+      continue;
+    auto *CDA = dyn_cast<ConstantDataArray>(GV.getInitializer());
+    if (!CDA)
+      continue;
+    StringRef Raw = CDA->getAsString();
+    uint64_t Len  = Raw.size();
+
+    uint8_t Key[8];
+    uint64_t RandKey = RNG.next();
+    for (unsigned I = 0; I < 8; ++I)
+      Key[I] = static_cast<uint8_t>((RandKey >> (I * 8)) & 0xFF);
+
+    std::vector<Constant *> EncBytes;
+    EncBytes.reserve(Len);
+    for (uint64_t I = 0; I < Len; ++I)
+      EncBytes.push_back(ConstantInt::get(Int8Ty,
+          static_cast<uint8_t>(Raw[I]) ^ Key[I % 8]));
+    auto *EncConst = ConstantArray::get(ArrayType::get(Int8Ty, Len), EncBytes);
+
+    const_cast<GlobalVariable &>(GV).setConstant(false);
+    const_cast<GlobalVariable &>(GV).setInitializer(EncConst);
+
+    std::string Suffix = std::to_string(RNG.next32());
+    Function *Stub = buildWideDecryptStub(
+        M, &const_cast<GlobalVariable &>(GV),
+        static_cast<unsigned>(Len), 8, Key, "kotlin_" + Suffix);
+    KotlinStubs.push_back(Stub);
+
+    Changed = true;
+  }
+
+  buildRuntimeStringDecryptCtor(M, KotlinStubs,
+                                 "kagura_kotlin_string_decrypt_ctor",
+                                 /*Priority=*/0);
 
   return Changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
 }

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -52,6 +52,20 @@ add_library(kagura_runtime STATIC
   game/integrity_report.c
 )
 
+# ---- A.1: Windows runtime stubs --------------------------------------------
+if(WIN32)
+  target_sources(kagura_runtime PRIVATE
+    windows/anti_debug.c
+    windows/integrity.c
+    windows/tamper_response.c
+    windows/device_key.c
+  )
+  target_link_libraries(kagura_runtime PRIVATE
+    ws2_32      # WinSock2  (anti_debug: Frida port check)
+    imagehlp    # MapFileAndCheckSum (integrity: PE checksum)
+  )
+endif()
+
 target_include_directories(kagura_runtime PUBLIC
   ${CMAKE_SOURCE_DIR}/include
 )

--- a/runtime/windows/anti_debug.c
+++ b/runtime/windows/anti_debug.c
@@ -1,0 +1,255 @@
+/*===-- runtime/windows/anti_debug.c - Windows anti-debug checks ----------===
+ *
+ * A.1: Windows runtime stubs for kagura anti-debug protection.
+ *
+ * Checks implemented:
+ *   kagura_check_debugger_present   — IsDebuggerPresent() (user-mode flag)
+ *   kagura_check_remote_debugger    — CheckRemoteDebuggerPresent()
+ *   kagura_check_nt_debug_port      — NtQueryInformationProcess(DebugPort)
+ *   kagura_check_heap_flags         — PEB heap flags set by debuggers
+ *   kagura_check_frida_port         — Frida default port 27042 on localhost
+ *   kagura_check_injected_dlls      — scan loaded modules for analysis tools
+ *   kagura_check_windows_debugger   — aggregate check, calls tamper on detect
+ *
+ * Public API (mirrors iOS/Android conventions):
+ *   int  kagura_check_*()  — 1 = detected, 0 = clean
+ *   void kagura_*_check()  — calls kagura_on_tamper_detected() on detection
+ *
+ *===----------------------------------------------------------------------===*/
+
+#ifdef _WIN32
+
+#include <stdint.h>
+#include <string.h>
+
+/* Avoid pulling in the full Windows SDK in LLVM pass-plugin builds.
+ * We forward-declare the minimal Win32 surface we need. */
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#include <winsock2.h>
+#include <tlhelp32.h>
+
+/* NtQueryInformationProcess — not in standard headers */
+typedef LONG (WINAPI *PFN_NtQueryInformationProcess)(
+    HANDLE ProcessHandle,
+    ULONG  ProcessInformationClass,
+    PVOID  ProcessInformation,
+    ULONG  ProcessInformationLength,
+    PULONG ReturnLength);
+
+#define ProcessDebugPort 7
+
+/* ---- Default tamper response -------------------------------------------- */
+
+__attribute__((weak)) void kagura_on_tamper_detected(void) {
+    ExitProcess(1);
+}
+
+/* ---- IsDebuggerPresent --------------------------------------------------- */
+
+int kagura_check_debugger_present(void) {
+    return IsDebuggerPresent() ? 1 : 0;
+}
+
+void kagura_debugger_present_check(void) {
+    if (kagura_check_debugger_present())
+        kagura_on_tamper_detected();
+}
+
+/* ---- CheckRemoteDebuggerPresent ------------------------------------------ */
+
+int kagura_check_remote_debugger(void) {
+    BOOL present = FALSE;
+    if (!CheckRemoteDebuggerPresent(GetCurrentProcess(), &present))
+        return 0; /* API failed — assume clean */
+    return present ? 1 : 0;
+}
+
+void kagura_remote_debugger_check(void) {
+    if (kagura_check_remote_debugger())
+        kagura_on_tamper_detected();
+}
+
+/* ---- NtQueryInformationProcess(DebugPort) -------------------------------- */
+/*
+ * The debug port is a kernel handle set when a debugger attaches via
+ * DebugActiveProcess().  A non-zero value means a kernel debugger is present.
+ * This check bypasses the user-mode IsDebuggerPresent flag which can be
+ * cleared trivially with WriteProcessMemory().
+ */
+int kagura_check_nt_debug_port(void) {
+    HMODULE hNtdll = GetModuleHandleA("ntdll.dll");
+    if (!hNtdll)
+        return 0;
+
+    PFN_NtQueryInformationProcess pfn =
+        (PFN_NtQueryInformationProcess)(void *)
+        GetProcAddress(hNtdll, "NtQueryInformationProcess");
+    if (!pfn)
+        return 0;
+
+    HANDLE port = NULL;
+    LONG status = pfn(GetCurrentProcess(), ProcessDebugPort,
+                      &port, sizeof(port), NULL);
+    /* STATUS_SUCCESS = 0 */
+    if (status != 0)
+        return 0;
+    return (port != NULL) ? 1 : 0;
+}
+
+void kagura_nt_debug_port_check(void) {
+    if (kagura_check_nt_debug_port())
+        kagura_on_tamper_detected();
+}
+
+/* ---- PEB heap flags ------------------------------------------------------- */
+/*
+ * When a process is launched under a debugger, the Windows loader sets two
+ * flags in the PEB's heap header:
+ *   NtGlobalFlag  bit 0x70 (FLG_HEAP_ENABLE_TAIL_CHECK |
+ *                            FLG_HEAP_ENABLE_FREE_CHECK |
+ *                            FLG_HEAP_VALIDATE_PARAMETERS)
+ * Reading the PEB directly avoids any user-mode API that can be hooked.
+ */
+int kagura_check_heap_flags(void) {
+#if defined(_M_X64) || defined(__x86_64__)
+    /* PEB is at GS:[0x60] on x64 */
+    BYTE *peb;
+    __asm__ volatile ("movq %%gs:0x60, %0" : "=r"(peb));
+    DWORD ntGlobalFlag = *(DWORD *)(peb + 0xBC);
+#elif defined(_M_IX86) || defined(__i386__)
+    /* PEB is at FS:[0x30] on x86 */
+    BYTE *peb;
+    __asm__ volatile ("movl %%fs:0x30, %0" : "=r"(peb));
+    DWORD ntGlobalFlag = *(DWORD *)(peb + 0x68);
+#else
+    return 0; /* unsupported architecture */
+#endif
+    return (ntGlobalFlag & 0x70) ? 1 : 0;
+}
+
+void kagura_heap_flags_check(void) {
+    if (kagura_check_heap_flags())
+        kagura_on_tamper_detected();
+}
+
+/* ---- Frida port check ---------------------------------------------------- */
+/*
+ * Frida's default agent port is 27042.  A successful connection to
+ * 127.0.0.1:27042 means Frida Server or Gadget is running.
+ */
+int kagura_check_frida_port(void) {
+    WSADATA wsa;
+    if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0)
+        return 0;
+
+    SOCKET s = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (s == INVALID_SOCKET) {
+        WSACleanup();
+        return 0;
+    }
+
+    /* Non-blocking connect with short timeout */
+    u_long mode = 1;
+    ioctlsocket(s, FIONBIO, &mode);
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family      = AF_INET;
+    addr.sin_port        = htons(27042);
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+    connect(s, (struct sockaddr *)&addr, sizeof(addr));
+
+    fd_set wfds;
+    FD_ZERO(&wfds);
+    FD_SET(s, &wfds);
+    struct timeval tv = { 0, 50000 }; /* 50 ms */
+    int result = select(0, NULL, &wfds, NULL, &tv);
+
+    closesocket(s);
+    WSACleanup();
+    return (result > 0) ? 1 : 0;
+}
+
+void kagura_frida_port_check(void) {
+    if (kagura_check_frida_port())
+        kagura_on_tamper_detected();
+}
+
+/* ---- Injected DLL scan --------------------------------------------------- */
+/*
+ * Enumerate loaded modules via CreateToolhelp32Snapshot and look for known
+ * analysis / instrumentation DLL names.
+ */
+int kagura_check_injected_dlls(void) {
+    static const char *kPatterns[] = {
+        "frida",
+        "frida-gadget",
+        "frida-agent",
+        "x64dbg",
+        "x32dbg",
+        "ollydbg",
+        "cheatengine",
+        "winspy",
+        "injector",
+        "minhook",
+        "detours",
+        NULL
+    };
+
+    HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE |
+                                            TH32CS_SNAPMODULE32, 0);
+    if (snap == INVALID_HANDLE_VALUE)
+        return 0;
+
+    MODULEENTRY32 me;
+    me.dwSize = sizeof(me);
+    if (!Module32First(snap, &me)) {
+        CloseHandle(snap);
+        return 0;
+    }
+
+    int found = 0;
+    do {
+        /* Convert module name to lowercase for case-insensitive match */
+        char lower[MAX_MODULE_NAME32 + 1];
+        size_t len = strlen(me.szModule);
+        if (len > MAX_MODULE_NAME32) len = MAX_MODULE_NAME32;
+        for (size_t i = 0; i < len; ++i)
+            lower[i] = (char)(me.szModule[i] >= 'A' && me.szModule[i] <= 'Z'
+                              ? me.szModule[i] + 32 : me.szModule[i]);
+        lower[len] = '\0';
+
+        for (int i = 0; kPatterns[i]; ++i) {
+            if (strstr(lower, kPatterns[i])) {
+                found = 1;
+                goto done;
+            }
+        }
+    } while (Module32Next(snap, &me));
+
+done:
+    CloseHandle(snap);
+    return found;
+}
+
+void kagura_injected_dlls_check(void) {
+    if (kagura_check_injected_dlls())
+        kagura_on_tamper_detected();
+}
+
+/* ---- Aggregate check ----------------------------------------------------- */
+
+void kagura_check_windows_debugger(void) {
+    if (kagura_check_debugger_present()  ||
+        kagura_check_remote_debugger()   ||
+        kagura_check_nt_debug_port()     ||
+        kagura_check_heap_flags()        ||
+        kagura_check_injected_dlls())
+        kagura_on_tamper_detected();
+}
+
+#endif /* _WIN32 */

--- a/runtime/windows/device_key.c
+++ b/runtime/windows/device_key.c
@@ -1,0 +1,99 @@
+/*===-- runtime/windows/device_key.c - Windows device-bound key derivation ===
+ *
+ * A.1: Derive a 16-byte device-bound key on Windows.
+ *
+ * The key is derived from:
+ *   - Machine SID (from HKLM\SAM or NetAPI32 — requires elevation on some
+ *     builds; fall back to ComputerName)
+ *   - Volume serial number of the system drive
+ *   - CPU vendor string
+ *
+ * All inputs are mixed with FNV-1a-32 and expanded to 16 bytes.
+ *
+ * Public API (mirrors runtime/core/device_key.c):
+ *   int  kagura_device_key(uint8_t out[16]);   // 1 = ok, 0 = failed
+ *   void kagura_device_mix_key(uint8_t key[16]); // XOR-mix key with device key
+ *
+ *===----------------------------------------------------------------------===*/
+
+#ifdef _WIN32
+
+#include <stdint.h>
+#include <string.h>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+/* ---- FNV-1a-32 ----------------------------------------------------------- */
+
+#define FNV_OFFSET_BASIS 0x811c9dc5u
+#define FNV_PRIME        0x01000193u
+
+static uint32_t fnv1a32(const uint8_t *data, size_t len) {
+    uint32_t h = FNV_OFFSET_BASIS;
+    for (size_t i = 0; i < len; ++i) {
+        h ^= data[i];
+        h *= FNV_PRIME;
+    }
+    return h;
+}
+
+/* ---- Collect device entropy ---------------------------------------------- */
+
+static uint32_t collect_machine_name(void) {
+    char name[MAX_COMPUTERNAME_LENGTH + 1];
+    DWORD sz = sizeof(name);
+    if (!GetComputerNameA(name, &sz))
+        return 0xDEADBEEFu;
+    return fnv1a32((const uint8_t *)name, sz);
+}
+
+static uint32_t collect_volume_serial(void) {
+    char sysdir[MAX_PATH];
+    if (!GetSystemDirectoryA(sysdir, MAX_PATH))
+        return 0xCAFEBABEu;
+    /* Truncate to root path (e.g. "C:\") */
+    sysdir[3] = '\0';
+    DWORD serial = 0;
+    if (!GetVolumeInformationA(sysdir, NULL, 0, &serial, NULL, NULL, NULL, 0))
+        return 0xFEEDFACEu;
+    return fnv1a32((const uint8_t *)&serial, sizeof(serial));
+}
+
+static uint32_t collect_cpu_id(void) {
+#if defined(_M_X64) || defined(__x86_64__) || \
+    defined(_M_IX86) || defined(__i386__)
+    int info[4] = {0};
+    /* CPUID leaf 0: vendor string in EBX/ECX/EDX */
+    __cpuid(info, 0);
+    return fnv1a32((const uint8_t *)(info + 1), 12);
+#else
+    return 0x13579BDFu;
+#endif
+}
+
+/* ---- Public API ---------------------------------------------------------- */
+
+int kagura_device_key(uint8_t out[16]) {
+    uint32_t parts[4];
+    parts[0] = collect_machine_name();
+    parts[1] = collect_volume_serial();
+    parts[2] = collect_cpu_id();
+    /* Fourth part: mix of the first three for avalanche effect */
+    parts[3] = fnv1a32((const uint8_t *)parts, 12);
+
+    memcpy(out, parts, 16);
+    return 1;
+}
+
+void kagura_device_mix_key(uint8_t key[16]) {
+    uint8_t dev[16];
+    if (!kagura_device_key(dev))
+        return;
+    for (int i = 0; i < 16; ++i)
+        key[i] ^= dev[i];
+}
+
+#endif /* _WIN32 */

--- a/runtime/windows/integrity.c
+++ b/runtime/windows/integrity.c
@@ -1,0 +1,97 @@
+/*===-- runtime/windows/integrity.c - Windows PE integrity checks ---------===
+ *
+ * A.1: Windows PE integrity and memory-protection checks.
+ *
+ * Checks implemented:
+ *   kagura_pe_checksum_valid     — verify PE optional header checksum
+ *   kagura_check_wx_pages        — scan for W+X (RWX) memory pages
+ *   kagura_pe_integrity_check    — aggregate PE check
+ *   kagura_memory_protection_check — aggregate memory-protection check
+ *
+ * Public API:
+ *   int  kagura_*_valid()   — 1 = valid/clean, 0 = tampered/suspicious
+ *   int  kagura_check_*()   — 1 = detected, 0 = clean
+ *   void kagura_*_check()   — calls kagura_on_tamper_detected() on detection
+ *
+ *===----------------------------------------------------------------------===*/
+
+#ifdef _WIN32
+
+#include <stdint.h>
+#include <string.h>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#include <imagehlp.h>   /* MapFileAndCheckSum */
+
+extern void kagura_on_tamper_detected(void);
+
+/* ---- PE optional-header checksum verification ---------------------------- */
+/*
+ * The PE optional header carries a checksum of the on-disk image computed by
+ * the linker.  MapFileAndCheckSum re-derives it from disk; a mismatch means
+ * the file has been patched (e.g. by a packer or unpacker that forgot to
+ * update the checksum).
+ *
+ * Note: many legitimate binaries ship with checksum == 0 (the linker only
+ * sets it for drivers and signed executables).  We treat 0 as "unchecked"
+ * and return 1 (valid) to avoid false positives.
+ */
+int kagura_pe_checksum_valid(void) {
+    char path[MAX_PATH];
+    if (!GetModuleFileNameA(NULL, path, MAX_PATH))
+        return 1; /* can't determine path — assume valid */
+
+    DWORD headerSum  = 0;
+    DWORD computedSum = 0;
+    if (MapFileAndCheckSumA(path, &headerSum, &computedSum) != CHECKSUM_SUCCESS)
+        return 1; /* API failed — assume valid */
+
+    if (headerSum == 0)
+        return 1; /* checksum not set — unchecked binary */
+
+    return (headerSum == computedSum) ? 1 : 0;
+}
+
+void kagura_pe_integrity_check(void) {
+    if (!kagura_pe_checksum_valid())
+        kagura_on_tamper_detected();
+}
+
+/* ---- W+X (RWX) memory page detection ------------------------------------- */
+/*
+ * Iterate the virtual address space with VirtualQuery().  Any region that is
+ * both PAGE_EXECUTE_READWRITE or PAGE_EXECUTE_WRITECOPY indicates a trampoline
+ * or code-injection page — suspicious in a normal (non-JIT) binary.
+ *
+ * Known-safe: .NET / V8 / LuaJIT mark JIT regions RWX; we cannot easily
+ * distinguish them here, so this check is conservative (skip MEM_IMAGE pages
+ * which are always backed by a mapped PE section).
+ */
+int kagura_check_wx_pages(void) {
+    MEMORY_BASIC_INFORMATION mbi;
+    LPVOID addr = NULL;
+
+    while (VirtualQuery(addr, &mbi, sizeof(mbi)) == sizeof(mbi)) {
+        if (mbi.State == MEM_COMMIT && mbi.Type == MEM_PRIVATE) {
+            DWORD prot = mbi.Protect & ~(PAGE_GUARD | PAGE_NOCACHE |
+                                         PAGE_WRITECOMBINE);
+            if (prot == PAGE_EXECUTE_READWRITE ||
+                prot == PAGE_EXECUTE_WRITECOPY) {
+                return 1;
+            }
+        }
+        /* Advance to the next region */
+        addr = (LPVOID)((uintptr_t)mbi.BaseAddress + mbi.RegionSize);
+    }
+    return 0;
+}
+
+void kagura_memory_protection_check(void) {
+    if (kagura_check_wx_pages())
+        kagura_on_tamper_detected();
+}
+
+#endif /* _WIN32 */

--- a/runtime/windows/tamper_response.c
+++ b/runtime/windows/tamper_response.c
@@ -1,0 +1,55 @@
+/*===-- runtime/windows/tamper_response.c - Windows tamper response -------===
+ *
+ * A.1: Windows-specific tamper response callbacks.
+ *
+ * kagura_on_tamper_detected() is declared __attribute__((weak)) in
+ * anti_debug.c so that application code can override it.  This file provides
+ * a secondary Windows-specific entry point that performs a clean process
+ * termination via ExitProcess() rather than abort() (which can show a
+ * crash dialog on Windows).
+ *
+ * The soft-response score helpers follow the same API as the Android/iOS
+ * implementations in soft_response.c.
+ *
+ *===----------------------------------------------------------------------===*/
+
+#ifdef _WIN32
+
+#include <stdint.h>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+/* ---- Soft-response score state ------------------------------------------ */
+
+#define KAGURA_THRESHOLD_WARN      10
+#define KAGURA_THRESHOLD_PENALISE  30
+#define KAGURA_THRESHOLD_KICK      60
+
+static volatile LONG g_score = 0;
+
+void kagura_soft_response_add(int score) {
+    InterlockedAdd(&g_score, (LONG)score);
+}
+
+int kagura_soft_response_level(void) {
+    LONG s = InterlockedCompareExchange(&g_score, 0, 0); /* atomic read */
+    if (s >= KAGURA_THRESHOLD_KICK)      return 3;
+    if (s >= KAGURA_THRESHOLD_PENALISE)  return 2;
+    if (s >= KAGURA_THRESHOLD_WARN)      return 1;
+    return 0;
+}
+
+void kagura_soft_response_reset(void) {
+    InterlockedExchange(&g_score, 0);
+}
+
+void kagura_soft_response_check(int threshold) {
+    extern void kagura_on_tamper_detected(void);
+    if (InterlockedCompareExchange(&g_score, 0, 0) >= (LONG)threshold)
+        kagura_on_tamper_detected();
+}
+
+#endif /* _WIN32 */

--- a/tests/lit/swift-kotlin-string-encryption.ll
+++ b/tests/lit/swift-kotlin-string-encryption.ll
@@ -1,0 +1,34 @@
+; RUN: %opt -load-pass-plugin=%kagura_plugin -passes=kagura-wstr -kagura-wstr -S %s | %FileCheck %s
+
+; WideStringEncryptionPass: Swift and Kotlin Native string constant coverage.
+;
+; After the pass:
+;   - Swift string plaintext ("Hello from Swift") must be absent.
+;   - Kotlin string plaintext ("Hello from Kotlin") must be absent.
+;   - Swift module constructor (kagura_swift_string_decrypt_ctor) must appear.
+;   - Kotlin module constructor (kagura_kotlin_string_decrypt_ctor) must appear.
+
+; CHECK-NOT: c"Hello from Swift"
+; CHECK-NOT: c"Hello from Kotlin"
+; CHECK: kagura_swift_string_decrypt_ctor
+; CHECK: kagura_kotlin_string_decrypt_ctor
+
+; Swift string literal: private [N x i8] with "$s" mangled name.
+@"$sSS16_builtinStringLiteralSSy_p_BpBwBitcfC.str" = private unnamed_addr constant [17 x i8] c"Hello from Swift\00"
+
+; Kotlin Native string literal: private [N x i8] with ".kotlin" prefix.
+@".kotlin_string_pool.hello" = private unnamed_addr constant [18 x i8] c"Hello from Kotlin\00"
+
+declare i32 @use_str(ptr)
+
+define i32 @test_swift() {
+entry:
+  %r = call i32 @use_str(ptr @"$sSS16_builtinStringLiteralSSy_p_BpBwBitcfC.str")
+  ret i32 %r
+}
+
+define i32 @test_kotlin() {
+entry:
+  %r = call i32 @use_str(ptr @".kotlin_string_pool.hello")
+  ret i32 %r
+}

--- a/tests/lit/vtp-msvc.ll
+++ b/tests/lit/vtp-msvc.ll
@@ -1,0 +1,37 @@
+; RUN: %opt -load-pass-plugin=%kagura_plugin -passes=kagura-vtp -kagura-vtp -S %s | %FileCheck %s
+
+; VTableProtectionPass MSVC ABI test.
+;
+; Checks:
+;   1. ??_7 vtable is tagged (kagura.vtables metadata emitted).
+;   2. ??_R0 TypeDescriptor name field is encrypted (plaintext ".?AVFoo@@" absent).
+;   3. A module constructor for in-place decryption is injected.
+
+target triple = "x86_64-pc-windows-msvc19.0.0"
+
+; CHECK-NOT: c".?AVFoo@@"
+; CHECK: msvc_rtti_decrypt
+; CHECK: kagura.vtables
+
+; MSVC vtable for class Foo
+@"??_7Foo@@6B@" = internal constant [2 x ptr] [
+  ptr @"?method1@Foo@@UAEXXZ",
+  ptr @"?method2@Foo@@UAEHXZ"
+]
+
+; MSVC TypeDescriptor for class Foo: { ptr vftable, ptr spare, [10 x i8] name }
+@"??_R0?AVFoo@@8" = internal constant { ptr, ptr, [10 x i8] } {
+  ptr null,
+  ptr null,
+  [10 x i8] c".?AVFoo@@\00"
+}
+
+declare void @"?method1@Foo@@UAEXXZ"()
+declare i32  @"?method2@Foo@@UAEHXZ"()
+
+define void @test() {
+entry:
+  %vt = load ptr, ptr @"??_7Foo@@6B@"
+  call void @"?method1@Foo@@UAEXXZ"()
+  ret void
+}

--- a/tests/lit/wide-string-encryption.ll
+++ b/tests/lit/wide-string-encryption.ll
@@ -3,13 +3,13 @@
 ; WideStringEncryptionPass encrypts wide-character (i16/i32) string globals.
 ; After the pass:
 ;   - The plaintext content of the wide string must not be present as-is.
-;   - An encrypted global (kagura_wenc_) must be emitted.
+;   - The original global is encrypted in-place (element values changed).
 ;   - A lazy-decrypt flag global (kagura_wflag_) must be emitted.
-;   - The original @wide_hello global must be gone or replaced.
+;   - A key global (kagura_wkey_) must be emitted.
 
 ; CHECK-NOT: i16 72, i16 101, i16 108
-; CHECK: @kagura_wenc_
 ; CHECK: @kagura_wflag_
+; CHECK: @kagura_wkey_
 
 ; Wide string: L"Hello" as i16 array
 @wide_hello = private unnamed_addr constant [6 x i16]


### PR DESCRIPTION
## Summary

- **A.1** Add `tests/lit/vtp-msvc.ll` — end-to-end FileCheck test for MSVC ABI in `VTableProtectionPass`, covering `??_7` vtable metadata tagging and `??_R0` TypeDescriptor name XOR-encryption with module constructor
- **A.2** Extend `WideStringEncryptionPass` to detect and encrypt Swift and Kotlin Native string constants:
  - Swift: `$s`-mangled private/internal `[N x i8]` globals → priority-(-1) ctor (before Swift runtime)
  - Kotlin Native: `kfun:` / `.kotlin*` / `_kotlin_` / `N6kotlin` patterns → priority-0 ctor
  - New lit test: `tests/lit/swift-kotlin-string-encryption.ll`
- **Bugfix** (pre-existing): `WideStringEncryptionPass` took the user-list snapshot *after* building the decrypt stub, causing stub-internal loads to receive spurious lazy-guard splits; fixed by moving snapshot before stub creation
- Update `tests/lit/wide-string-encryption.ll` checks to match actual in-place encryption output

## Test plan

- [x] `cmake --build build --target KaguraObfuscator` — clean build, no warnings
- [x] `tests/lit/vtp-msvc.ll` — FileCheck PASS
- [x] `tests/lit/wide-string-encryption.ll` — FileCheck PASS
- [x] `tests/lit/swift-kotlin-string-encryption.ll` — FileCheck PASS
- [x] `cmake --build build --target check-kagura` — integration tests PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)