### PR TITLE
feat(wasm): implement C.1 WebAssembly backend pass filtering

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,5 +16,5 @@ Features that were not implemented in Phase 4 and are candidates for future work
 | B.1 | Decompiler resistance scoring | Medium | Automate Binary Ninja / Ghidra analysis to produce a quantitative resilience score; feed back into AutoSelectPass |
 | B.2 | CallIndirection hot-path cache | Medium | Resolution happens on every call; a per-site cache would reduce overhead on hot paths |
 | B.3 | Deterministic obfuscation sessions | Medium | Given the same seed key and IR, produce a bit-identical output binary to ensure CI reproducibility |
-| C.1 | WebAssembly backend support | Low | Unity WebGL and other Wasm targets are growing; needs a Wasm-aware pass pipeline |
+| ~~C.1~~ | ~~WebAssembly backend support~~ | ~~Low~~ | ~~Implemented: `isWasmTarget()` helper + early-exit guards in AntiDebug, PointerAuth, AntiTamper, VMObfuscation, ControlFlowFlattening; AutoSelect skips FLA on Wasm; LIT test wasm-pass-filter.ll~~ |
 | C.2 | Automated MBA expression generation | Low | Current SUB uses fixed patterns; auto-generate Z3-verified equivalent expressions for richer MBA substitution |

--- a/include/kagura/Utils.h
+++ b/include/kagura/Utils.h
@@ -76,6 +76,8 @@ enum class TargetArch {
   ARM64e,  // AArch64 with hardware PAC (apple-arm64e)
   ARMv7,   // 32-bit ARM
   X86_64,  // x86-64
+  Wasm32,  // WebAssembly (32-bit linear memory)
+  Wasm64,  // WebAssembly (64-bit linear memory)
   Other,
 };
 
@@ -99,6 +101,11 @@ bool isARMv7Target(const llvm::Module &M);
 
 /// Returns true if the module targets x86-64.
 bool isX86_64Target(const llvm::Module &M);
+
+/// Returns true if the module targets WebAssembly (wasm32 or wasm64).
+/// Passes that use platform-specific syscalls, Mach-O sections, ELF/PE
+/// structure, or hardware PAC must skip themselves on Wasm targets.
+bool isWasmTarget(const llvm::Module &M);
 
 // ---- String global collection ----
 

--- a/lib/Transforms/AntiAnalysis/AntiDebug.cpp
+++ b/lib/Transforms/AntiAnalysis/AntiDebug.cpp
@@ -149,6 +149,11 @@ static Function *buildAntiDebugConstructor(Module &M, bool AntiFramework,
 }
 
 PreservedAnalyses AntiDebugPass::run(Module &M, ModuleAnalysisManager &) {
+  // C.1: Anti-debug checks rely on platform syscalls (ptrace, /proc, Mach-O
+  // dylib introspection) that do not exist in WebAssembly sandboxes.
+  if (kagura::isWasmTarget(M))
+    return PreservedAnalyses::all();
+
   auto *Ctor = buildAntiDebugConstructor(M, AntiFramework, AntiPtrace);
   // Register as module constructor (priority 0 = runs first)
   appendToGlobalCtors(M, Ctor, 0);

--- a/lib/Transforms/AntiAnalysis/AntiTamper.cpp
+++ b/lib/Transforms/AntiAnalysis/AntiTamper.cpp
@@ -216,6 +216,11 @@ static bool isTamperEligible(Function &F, bool GlobalFlag) {
 //===----------------------------------------------------------------------===//
 
 PreservedAnalyses AntiTamperPass::run(Module &M, ModuleAnalysisManager &) {
+  // C.1: Integrity checks call platform runtime functions (jailbreak detection,
+  // kagura_self_check) that are not available in the WebAssembly sandbox.
+  if (kagura::isWasmTarget(M))
+    return PreservedAnalyses::all();
+
   bool Changed = false;
 
   // Pre-declare all runtime symbols once so that every injection below can

--- a/lib/Transforms/AntiAnalysis/PointerAuth.cpp
+++ b/lib/Transforms/AntiAnalysis/PointerAuth.cpp
@@ -409,6 +409,12 @@ PreservedAnalyses PointerAuthPass::run(Module &M, ModuleAnalysisManager &) {
   if (!kagura::opt::PAC)
     return PreservedAnalyses::all();
 
+  // C.1: Pointer authentication uses hardware PAC (arm64e) or XOR tagging.
+  // WebAssembly has neither native PAC nor mutable function-pointer globals
+  // that benefit from software tagging — skip to avoid invalid lowering.
+  if (kagura::isWasmTarget(M))
+    return PreservedAnalyses::all();
+
   // 4.1.8: On arm64e, prefer hardware PAC (pacia/autia intrinsics).
   const bool UseHardwarePAC = kagura::isArm64eTarget(M);
   if (UseHardwarePAC) {

--- a/lib/Transforms/CFG/ControlFlowFlattening.cpp
+++ b/lib/Transforms/CFG/ControlFlowFlattening.cpp
@@ -162,6 +162,12 @@ static bool flattenFunction(Function &F, PRNG &RNG) {
 
 PreservedAnalyses
 ControlFlowFlatteningPass::run(Function &F, FunctionAnalysisManager &) {
+  // C.1: FLA rewires the entire CFG into a switch dispatch and relies on
+  // reg2mem (DemotePHIToStack / DemoteRegToStack).  The Wasm target requires
+  // structured control flow and does not support arbitrary CFG reshaping.
+  if (kagura::isWasmTarget(*F.getParent()))
+    return PreservedAnalyses::all();
+
   if (!shouldObfuscate(F, "fla", true))
     return PreservedAnalyses::all();
   auto &RNG    = getModulePRNG();

--- a/lib/Transforms/Infrastructure/AutoSelect.cpp
+++ b/lib/Transforms/Infrastructure/AutoSelect.cpp
@@ -136,6 +136,12 @@ PreservedAnalyses AutoSelectPass::run(Module &M, ModuleAnalysisManager &) {
   if (!kagura::opt::AutoSelect)
     return PreservedAnalyses::all();
 
+  // C.1: On Wasm, FLA and VM passes are disabled (structured control flow
+  // requirement).  AutoSelect must not annotate these passes on Wasm targets
+  // even when the global flags are on — the per-function annotation would
+  // bypass the guard inside each pass.
+  const bool IsWasm = kagura::isWasmTarget(M);
+
   for (auto &F : M) {
     if (F.isDeclaration() || F.isVarArg()) continue;
 
@@ -173,7 +179,8 @@ PreservedAnalyses AutoSelectPass::run(Module &M, ModuleAnalysisManager &) {
       // Heavy: FLA + BCF + BBR + BBS + MVO + PE + SUB
       // Skip FLA and VM for very large functions (> 200 instructions)
       // to avoid excessive code size blowup.
-      if (kagura::opt::FLA && Features.Insts <= 200)
+      // Skip FLA on Wasm (structured control flow requirement).
+      if (kagura::opt::FLA && Features.Insts <= 200 && !IsWasm)
         annotateIfAbsent(F, "fla");
       if (kagura::opt::BCF) annotateIfAbsent(F, "bcf");
       if (kagura::opt::BBR) annotateIfAbsent(F, "bbr");

--- a/lib/Transforms/Platform/VMObfuscation.cpp
+++ b/lib/Transforms/Platform/VMObfuscation.cpp
@@ -456,6 +456,11 @@ static bool buildTrampoline(Function &F, ArrayRef<uint8_t> Bytecode,
 
 PreservedAnalyses VMObfuscationPass::run(Function &F,
                                           FunctionAnalysisManager &) {
+  // C.1: The VM interpreter uses platform-specific indirect dispatch and
+  // function pointer manipulation that does not lower correctly on Wasm.
+  if (kagura::isWasmTarget(*F.getParent()))
+    return PreservedAnalyses::all();
+
   if (!shouldObfuscate(F, "vm", true)) return PreservedAnalyses::all();
   if (!canVirtualize(F)) return PreservedAnalyses::all();
 

--- a/lib/Transforms/Utils.cpp
+++ b/lib/Transforms/Utils.cpp
@@ -220,6 +220,10 @@ TargetArch getTargetArch(const Module &M) {
     return TargetArch::ARMv7;
   if (Triple.starts_with("x86_64") || Triple.starts_with("amd64"))
     return TargetArch::X86_64;
+  if (Triple.starts_with("wasm64"))
+    return TargetArch::Wasm64;
+  if (Triple.starts_with("wasm32"))
+    return TargetArch::Wasm32;
   return TargetArch::Other;
 }
 
@@ -238,6 +242,11 @@ bool isARMv7Target(const Module &M) {
 
 bool isX86_64Target(const Module &M) {
   return getTargetArch(M) == TargetArch::X86_64;
+}
+
+bool isWasmTarget(const Module &M) {
+  TargetArch A = getTargetArch(M);
+  return A == TargetArch::Wasm32 || A == TargetArch::Wasm64;
 }
 
 // ---- IR helpers ----

--- a/tests/lit/wasm-pass-filter.ll
+++ b/tests/lit/wasm-pass-filter.ll
@@ -1,0 +1,23 @@
+; RUN: %opt -load-pass-plugin=%kagura_plugin \
+; RUN:   -passes="function(kagura-fla,kagura-vm),kagura-anti-debug,kagura-tamper,kagura-pac" \
+; RUN:   -S %s | %FileCheck %s
+
+; C.1: Passes that require platform-specific features or unstructured CFG must
+; be no-ops on WebAssembly targets.  Verify that the function body is
+; unchanged after running the full incompatible pass set.
+
+; CHECK: define i32 @add(i32 %a, i32 %b)
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %sum = add i32 %a, %b
+; CHECK-NEXT: ret i32 %sum
+; CHECK-NOT: switch
+; CHECK-NOT: kagura_anti_debug_init
+; CHECK-NOT: kagura_pac_key
+
+target triple = "wasm32-unknown-unknown"
+
+define i32 @add(i32 %a, i32 %b) {
+entry:
+  %sum = add i32 %a, %b
+  ret i32 %sum
+}


### PR DESCRIPTION
## Summary

- Add `isWasmTarget(Module &)` helper (splitmix64 analogue for Wasm32/Wasm64 detection)
- Add `Wasm32` / `Wasm64` variants to `TargetArch` enum
- Early-return guards in 5 passes incompatible with Wasm:
  - `AntiDebugPass` — platform syscalls (ptrace, /proc, dylib scan) absent in sandbox
  - `PointerAuthPass` — hardware PAC and XOR tagging don't lower on Wasm
  - `AntiTamperPass` — jailbreak/integrity runtime not available in sandbox
  - `ControlFlowFlatteningPass` — Wasm requires structured control flow
  - `VMObfuscationPass` — indirect dispatch / function-pointer manipulation invalid
- `AutoSelectPass` skips FLA annotation on Wasm to prevent bypass via metadata
- `ObjCObfuscation` and `JNIObfuscation` already had platform guards covering Wasm
- New LIT test: `tests/lit/wasm-pass-filter.ll` — verifies all incompatible passes are no-ops on `wasm32-unknown-unknown`

## Test plan

- [ ] All 39 existing tests pass (`ctest`)
- [ ] `wasm-pass-filter.ll` FileCheck passes (function body unchanged after full pass set)
- [ ] CI matrix (LLVM 17–22, macOS arm64) green