### PR TITLE
refactor: remove implementation phase numbers from comments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ elseif(WIN32)
 endif()
 # ---------------------------------------------------------------------------
 
-# ---- 4.6.8 Build cache support -------------------------------------------
+# ---- Build cache support ----------------------------------------------------
 # Enable ccache / sccache if available. Set KAGURA_USE_CACHE=OFF to disable.
 option(KAGURA_USE_CACHE "Use compiler cache (ccache/sccache) if available" ON)
 if(KAGURA_USE_CACHE)
@@ -68,7 +68,7 @@ include(AddLLVM)
 # Kagura includes
 include_directories(${CMAKE_SOURCE_DIR}/include)
 
-# ---- 4.6.7 Incremental build support ------------------------------------
+# ---- Incremental build support ----------------------------------------------
 # kagura-opt and the pass plugin both support incremental builds naturally
 # via CMake's dependency tracking.  The following options control additional
 # incremental-build optimisations:
@@ -87,7 +87,7 @@ if(KAGURA_PCH)
 endif()
 # --------------------------------------------------------------------------
 
-# ---- 4.1.3 Legacy pass manager compatibility ----------------------------
+# ---- Legacy pass manager compatibility --------------------------------------
 # When KAGURA_LEGACY_PM=ON, LegacyPlugin.cpp is compiled into the shared
 # library and registers all kagura passes with LLVM 14-16's legacy PM via
 # PassManagerBuilder extension points and RegisterPass<>.
@@ -104,7 +104,7 @@ if(KAGURA_LEGACY_PM)
 endif()
 # --------------------------------------------------------------------------
 
-# ---- 4.1.5 Bitcode input support -----------------------------------------
+# ---- Bitcode input support --------------------------------------------------
 # When KAGURA_BITCODE_TOOLS=ON, build a small standalone tool (kagura-opt)
 # that wraps `opt` and auto-loads the kagura plugin, so users can run kagura
 # passes on .bc / .ll files without needing a full clang invocation.

--- a/TODO.md
+++ b/TODO.md
@@ -4,10 +4,10 @@ Features that were not implemented in Phase 4 and are candidates for future work
 
 | ID | Feature | Priority | Notes |
 |:---|:--------|:---------|:------|
-| 4.2.11 | White-box cryptography | Low | AES/TDES white-box key encoding so the cipher key is never exposed in plaintext even under full memory disclosure |
-| 4.7.9 | Device farm tests (iOS/Android real devices) | Low | Run the integration test suite on physical iOS and Android devices via a cloud device farm (e.g. Firebase Test Lab, AWS Device Farm) |
-| 4.8.9 | ML/heuristic-based protection target inference | Low | Use static features (cyclomatic complexity, symbol names, call graph centrality) to recommend which functions to protect |
-| 4.8.10 | Machine code / backend-level obfuscation | Low | Apply obfuscation at the assembler / MachineFunction level (after instruction selection) for deeper resistance to IR-level static analysis |
+| — | White-box cryptography | Low | AES/TDES white-box key encoding so the cipher key is never exposed in plaintext even under full memory disclosure |
+| — | Device farm tests (iOS/Android real devices) | Low | Run the integration test suite on physical iOS and Android devices via a cloud device farm (e.g. Firebase Test Lab, AWS Device Farm) |
+| — | ML/heuristic-based protection target inference | Low | Use static features (cyclomatic complexity, symbol names, call graph centrality) to recommend which functions to protect |
+| — | Machine code / backend-level obfuscation | Low | Apply obfuscation at the assembler / MachineFunction level (after instruction selection) for deeper resistance to IR-level static analysis |
 | — | MSVC ABI support in VTableProtection | Med | Handle `??_7` / `??_R` MSVC naming conventions in addition to Itanium `_ZTV`/`_ZTS`/`_ZTI`; required for Windows target support |
 | — | Regression corpus expansion | High | Only one entry in tests/regression/corpus/; add .ll test cases covering EH, PHI-heavy, vararg, empty, and large functions for each pass |
 | ~~A.1~~ | ~~Windows/MSVC build support~~ | ~~High~~ | ~~Implemented: MSVC/Clang-CL CMake flags, Windows CI job (LLVM 17/19), runtime/windows/ stubs (anti_debug, integrity, tamper_response, device_key), vtp-msvc.ll lit test~~ |

--- a/include/kagura/Options.h
+++ b/include/kagura/Options.h
@@ -36,13 +36,13 @@ extern llvm::cl::opt<bool> CI;
 extern llvm::cl::opt<bool> PAC;
 extern llvm::cl::opt<bool> GENC;
 
-/// 4.5.2: XOR-encrypt alloca'd pointer values to defeat memory dump analysis.
+/// XOR-encrypt alloca'd pointer values to defeat memory dump analysis.
 extern llvm::cl::opt<bool> PE;
 
-/// 4.5.6: Inject telemetry event calls at function entry.
+/// Inject telemetry event calls at function entry.
 extern llvm::cl::opt<bool> Telemetry;
 
-/// 4.3.16: Inject basic-block-level opcode checksum guards.
+/// Inject basic-block-level opcode checksum guards.
 extern llvm::cl::opt<bool> BBCheck;
 extern llvm::cl::opt<bool> VTP;
 extern llvm::cl::opt<bool> ELT;
@@ -54,73 +54,73 @@ extern llvm::cl::opt<uint32_t> SUBIter;
 extern llvm::cl::opt<uint32_t> DCIProb;
 extern llvm::cl::opt<uint64_t> Seed;
 
-// ---- Phase 4.1 infrastructure flags ----
+// ---- Infrastructure flags ----
 
-/// 4.1.1 / 4.1.2: Enable protection during LTO/ThinLTO pipeline phases.
+/// Enable protection during LTO/ThinLTO pipeline phases.
 /// When false (default), kagura skips module passes that are unsafe to run
 /// during link-time optimisation (e.g. passes that assume single-module IR).
 extern llvm::cl::opt<bool> LTOSafe;
 
-/// 4.1.2: Enable a lightweight pass subset at -O0 (debug builds).
+/// Enable a lightweight pass subset at -O0 (debug builds).
 /// When false (default), all passes are skipped at O0 for build speed.
 extern llvm::cl::opt<bool> O0Protect;
 
-/// 4.1.6: DWARF / debug-info handling mode.
+/// DWARF / debug-info handling mode.
 ///   "keep"  (default) — preserve all debug info unchanged.
 ///   "strip" — remove all debug metadata from functions touched by kagura.
 ///   "obfuscate" — remap source locations to synthetic coordinates.
 extern llvm::cl::opt<std::string> DWARFMode;
 
-// ---- Phase 4.2 data-protection flags ----
+// ---- Data-protection flags ----
 
-/// 4.2.1: Encrypt wide-character (wchar_t / char16_t / char32_t) string
+/// Encrypt wide-character (wchar_t / char16_t / char32_t) string
 /// literals and ObjC/CoreFoundation CFString backing buffers.
 extern llvm::cl::opt<bool> WSTR;
 
-// ---- Phase 4.5 game / anti-cheat flags ----
+// ---- Game / anti-cheat flags ----
 
-/// 4.5.1: In-memory integer variable XOR obfuscation.
+/// In-memory integer variable XOR obfuscation.
 extern llvm::cl::opt<bool> MVO;
 
-/// 4.5.3 / 4.5.4: Honey value / decoy variable and fake symbol injection.
+/// Honey value / decoy variable and fake symbol injection.
 extern llvm::cl::opt<bool> Honey;
 
-// ---- Phase 4.6 build-system / DX flags ----
+// ---- Build-system / DX flags ----
 
-/// 4.8.1: Auto-select obfuscation passes per function based on risk score.
+/// Auto-select obfuscation passes per function based on risk score.
 extern llvm::cl::opt<bool> AutoSelect;
 
-/// 4.6.1: Path to the JSON policy configuration file.
+/// Path to the JSON policy configuration file.
 extern llvm::cl::opt<std::string> ConfigFile;
 
-/// 4.6.3: Comma-separated list of symbol name patterns to force-protect
+/// Comma-separated list of symbol name patterns to force-protect
 /// (overrides per-function annotations; supports '*' glob suffix).
 extern llvm::cl::opt<std::string> ProtectList;
 
-/// 4.6.4: Comma-separated list of symbol/file/module patterns to exclude
+/// Comma-separated list of symbol/file/module patterns to exclude
 /// from all kagura passes.  Supports '*' glob suffix matching.
 extern llvm::cl::opt<std::string> DenyList;
 
-/// 4.6.4: Comma-separated list of symbol/file/module patterns to explicitly
+/// Comma-separated list of symbol/file/module patterns to explicitly
 /// include (allowlist mode).  When non-empty, only matching symbols are
 /// obfuscated (everything else is treated as denied).
 extern llvm::cl::opt<std::string> AllowList;
 
-/// 4.6.5: Enable symbol map output.
+/// Enable symbol map output.
 extern llvm::cl::opt<bool> SymMap;
 
-/// 4.6.5: Output path for the symbol map JSON file.
+/// Output path for the symbol map JSON file.
 extern llvm::cl::opt<std::string> SymMapOut;
 
-/// 4.6.10: Emit an audit log recording what was protected and how.
+/// Emit an audit log recording what was protected and how.
 extern llvm::cl::opt<bool> AuditLog;
 
-/// 4.6.10: Output path for the audit log (default: kagura_audit.json).
+/// Output path for the audit log (default: kagura_audit.json).
 extern llvm::cl::opt<std::string> AuditLogOut;
 
-// ---- Phase 4.2 additional flags ----
+// ---- Additional flags ----
 
-/// 4.2.7: A build-time identifier string mixed into the PRNG seed so every
+/// A build-time identifier string mixed into the PRNG seed so every
 /// build produces different keys even with the same -kagura-seed value.
 /// Typically set to a CI build number, git commit hash, or timestamp.
 extern llvm::cl::opt<std::string> BuildID;

--- a/include/kagura/Passes.h
+++ b/include/kagura/Passes.h
@@ -219,9 +219,9 @@ struct DeadCodeInsertionPass
   static bool isRequired() { return false; }
 };
 
-// ---- Phase 4.5 Game / Anti-Cheat ----
+// ---- Game / Anti-Cheat ----
 
-/// 4.5.2: XOR-encrypts alloca'd pointer variables to defeat memory dump
+/// XOR-encrypts alloca'd pointer variables to defeat memory dump
 /// analysis by obscuring raw pointer addresses in game object fields.
 struct PointerEncryptionPass : public llvm::PassInfoMixin<PointerEncryptionPass> {
   llvm::PreservedAnalyses run(llvm::Function &F,
@@ -229,7 +229,7 @@ struct PointerEncryptionPass : public llvm::PassInfoMixin<PointerEncryptionPass>
   static bool isRequired() { return false; }
 };
 
-/// 4.5.1: XOR-encrypts local (alloca'd) integer variables at every store site
+/// XOR-encrypts local (alloca'd) integer variables at every store site
 /// and decrypts at every load site, protecting in-memory values from memory
 /// dump and debugger inspection.
 struct MemoryValueObfuscationPass
@@ -239,7 +239,7 @@ struct MemoryValueObfuscationPass
   static bool isRequired() { return false; }
 };
 
-/// 4.5.3 / 4.5.4: Injects decoy global variables containing fake secrets and
+/// Injects decoy global variables containing fake secrets and
 /// stub functions with plausible security-sounding names to mislead attackers.
 struct HoneyValuePass : public llvm::PassInfoMixin<HoneyValuePass> {
   llvm::PreservedAnalyses run(llvm::Module &M,
@@ -247,9 +247,9 @@ struct HoneyValuePass : public llvm::PassInfoMixin<HoneyValuePass> {
   static bool isRequired() { return false; }
 };
 
-// ---- Phase 4.3 Anti-Tamper (additional) ----
+// ---- Anti-Tamper (additional) ----
 
-/// 4.3.16: Injects compile-time opcode checksums and runtime verification
+/// Injects compile-time opcode checksums and runtime verification
 /// calls into a random subset of basic blocks to detect binary patching.
 struct BasicBlockChecksumPass
     : public llvm::PassInfoMixin<BasicBlockChecksumPass> {
@@ -258,9 +258,9 @@ struct BasicBlockChecksumPass
   static bool isRequired() { return false; }
 };
 
-// ---- Phase 4.5 Game / Anti-Cheat (additional) ----
+// ---- Game / Anti-Cheat (additional) ----
 
-/// 4.5.6: Injects a call to kagura_telemetry_event(uint32_t id) at the entry
+/// Injects a call to kagura_telemetry_event(uint32_t id) at the entry
 /// of instrumented functions to collect behavioral signals for cheat detection.
 struct TelemetryPass : public llvm::PassInfoMixin<TelemetryPass> {
   llvm::PreservedAnalyses run(llvm::Function &F,
@@ -268,9 +268,9 @@ struct TelemetryPass : public llvm::PassInfoMixin<TelemetryPass> {
   static bool isRequired() { return false; }
 };
 
-// ---- Phase 4.6 Build System / DX ----
+// ---- Build System / DX ----
 
-/// 4.6.10: Emits a JSON audit log recording all obfuscated functions and
+/// Emits a JSON audit log recording all obfuscated functions and
 /// which passes were applied.  Run AFTER all obfuscation passes.
 struct AuditLogPass : public llvm::PassInfoMixin<AuditLogPass> {
   llvm::PreservedAnalyses run(llvm::Module &M,
@@ -278,7 +278,7 @@ struct AuditLogPass : public llvm::PassInfoMixin<AuditLogPass> {
   static bool isRequired() { return false; }
 };
 
-/// 4.8.1: Analyzes each function's IR characteristics (cyclomatic complexity,
+/// Analyzes each function's IR characteristics (cyclomatic complexity,
 /// instruction count, alloca types, string refs) and annotates functions with
 /// the appropriate kagura pass set. Run BEFORE other obfuscation passes.
 /// Respects existing per-function annotations and globally-disabled passes.
@@ -288,7 +288,7 @@ struct AutoSelectPass : public llvm::PassInfoMixin<AutoSelectPass> {
   static bool isRequired() { return false; }
 };
 
-/// 4.6.1 + 4.6.2: Reads a JSON policy file and applies per-module protection
+/// Reads a JSON policy file and applies per-module protection
 /// settings, including profile presets (FAST / BALANCED / STRONG) and
 /// per-pass enable/disable overrides.  Run BEFORE other passes.
 struct ConfigLoaderPass : public llvm::PassInfoMixin<ConfigLoaderPass> {
@@ -297,7 +297,7 @@ struct ConfigLoaderPass : public llvm::PassInfoMixin<ConfigLoaderPass> {
   static bool isRequired() { return false; }
 };
 
-/// 4.6.5: Emits a JSON symbol map recording original and obfuscated names.
+/// Emits a JSON symbol map recording original and obfuscated names.
 /// Run AFTER all obfuscation passes.
 struct SymbolMapPass : public llvm::PassInfoMixin<SymbolMapPass> {
   llvm::PreservedAnalyses run(llvm::Module &M,
@@ -305,7 +305,7 @@ struct SymbolMapPass : public llvm::PassInfoMixin<SymbolMapPass> {
   static bool isRequired() { return false; }
 };
 
-// ---- Phase 4.2 Data Protection ----
+// ---- Data Protection ----
 
 /// Encrypts wide-character string literals (wchar_t / char16_t / char32_t)
 /// and ObjC/CoreFoundation CFString backing buffers using XOR with a
@@ -318,9 +318,9 @@ struct WideStringEncryptionPass
   static bool isRequired() { return false; }
 };
 
-// ---- Phase 4.2 Encrypted lookup table ----
+// ---- Encrypted lookup table ----
 
-/// 4.2.10: Transforms eligible switch statements into XOR-encrypted lookup
+/// Transforms eligible switch statements into XOR-encrypted lookup
 /// tables.  Contiguous constant-return switches with N <= 64 cases and 8-bit
 /// output values are replaced with a bounds-checked table load + XOR decrypt.
 struct EncryptedLookupTablePass
@@ -330,9 +330,9 @@ struct EncryptedLookupTablePass
   static bool isRequired() { return false; }
 };
 
-// ---- Phase 4.1 RTTI / vtable protection ----
+// ---- RTTI / vtable protection ----
 
-/// 4.1.11: Obfuscates C++ RTTI typeinfo name strings (_ZTS) using XOR
+/// Obfuscates C++ RTTI typeinfo name strings (_ZTS) using XOR
 /// encryption with a per-string key, and records vtable metadata for
 /// runtime integrity checking via kagura_vtable_check().
 struct VTableProtectionPass
@@ -342,7 +342,7 @@ struct VTableProtectionPass
   static bool isRequired() { return false; }
 };
 
-// ---- Phase 4.1 Infrastructure ----
+// ---- Infrastructure ----
 
 /// Controls DWARF / debug-info metadata on functions touched by kagura.
 ///

--- a/include/kagura/game_protect.h
+++ b/include/kagura/game_protect.h
@@ -1,6 +1,6 @@
 /*===-- kagura/game_protect.h - Game logic value protection template ------===
  *
- * 4.5.11: Provides C++ template wrappers for protecting game-critical values
+ * Provides C++ template wrappers for protecting game-critical values
  * (HP, damage, currency, speed, etc.) from memory scanners and freeze tools
  * such as GameGuardian, Cheat Engine, and memory editors.
  *

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -14,16 +14,14 @@ set(KAGURA_SOURCES
   ObfuscationMetrics.cpp
   $<$<BOOL:${KAGURA_LEGACY_PM}>:LegacyPlugin.cpp>
 
-  # Phase 4.1 Infrastructure
+  # Infrastructure
   Infrastructure/DWARFControl.cpp
-  # Phase 4.8 Automation
   Infrastructure/AutoSelect.cpp
-  # Phase 4.6 Build System / DX
   Infrastructure/ConfigLoader.cpp
   Infrastructure/SymbolMap.cpp
   Infrastructure/AuditLog.cpp
 
-  # Phase 4.1.11 RTTI / vtable protection
+  # RTTI / vtable protection
   CFG/VTableProtection.cpp
 
   # CFG obfuscation
@@ -86,12 +84,12 @@ target_include_directories(KaguraObfuscator PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-# ---- 4.1.3 Legacy PM compile definition ------------------------------------
+# ---- Legacy PM compile definition ------------------------------------------
 if(KAGURA_LEGACY_PM)
   target_compile_definitions(KaguraObfuscator PRIVATE KAGURA_LEGACY_PM=1)
 endif()
 
-# ---- 4.6.7 Incremental build: precompiled header ---------------------------
+# ---- Incremental build: precompiled header ----------------------------------
 # PCH is not supported on static libraries in all CMake versions; skip on
 # the fallback static build to keep the Windows build simple.
 if(KAGURA_PCH AND LLVM_ENABLE_PLUGINS)
@@ -106,7 +104,7 @@ if(KAGURA_PCH AND LLVM_ENABLE_PLUGINS)
   )
 endif()
 
-# ---- 4.6.7 Incremental build: unity build ----------------------------------
+# ---- Incremental build: unity build ----------------------------------------
 if(KAGURA_UNITY_BUILD)
   set_target_properties(KaguraObfuscator PROPERTIES UNITY_BUILD ON)
   set_source_files_properties(

--- a/runtime/android/android_root_advanced.c
+++ b/runtime/android/android_root_advanced.c
@@ -1,7 +1,7 @@
 /*===-- runtime/android_root_advanced.c - Magisk/Zygisk/Xposed detection --===
  *
- * 4.4.10: Magisk and Zygisk detection.
- * 4.4.11: Xposed / LSPosed detection.
+ * Magisk and Zygisk detection.
+ * Xposed / LSPosed detection.
  *
  * These checks complement the basic root detection in jailbreak_detection.c
  * with framework-specific indicators that survive Magisk Hide / DenyList and
@@ -68,7 +68,7 @@ static int _maps_contain(const char *fragment) {
 }
 
 /* -------------------------------------------------------------------------
- * 4.4.10: Magisk / Zygisk detection
+ * Magisk / Zygisk detection
  * ---------------------------------------------------------------------- */
 
 /* Known Magisk artifact paths that survive MagiskHide at the native layer */
@@ -113,7 +113,7 @@ void kagura_magisk_check(void) {
 }
 
 /* -------------------------------------------------------------------------
- * 4.4.11: Xposed / LSPosed detection
+ * Xposed / LSPosed detection
  * ---------------------------------------------------------------------- */
 
 static const char *kXposedPaths[] = {

--- a/runtime/android/apk_integrity.c
+++ b/runtime/android/apk_integrity.c
@@ -1,6 +1,6 @@
 /*===-- runtime/apk_integrity.c - Android APK signature verification ------===
  *
- * 4.3.4: Verifies that the APK has a valid Android v2/v3 signature block at
+ * Verifies that the APK has a valid Android v2/v3 signature block at
  * runtime on Android devices.  The check detects:
  *
  *   a. Missing APK Signing Block — the 16-byte magic "APK Sig Block 42" must

--- a/runtime/android/art_environment.c
+++ b/runtime/android/art_environment.c
@@ -1,6 +1,6 @@
 /*===-- runtime/art_environment.c - ART/JIT environment checks ------------===
  *
- * 4.4.15: Detect ART/JIT environment indicators on Android that may signal
+ * Detect ART/JIT environment indicators on Android that may signal
  *         a dynamic analysis or instrumentation environment.
  *
  * Checks:

--- a/runtime/android/direct_syscall.c
+++ b/runtime/android/direct_syscall.c
@@ -1,6 +1,6 @@
 /*===-- runtime/direct_syscall.c - Direct syscall invocation for hook bypass
  *
- * 4.3.11: Issue security-sensitive syscalls directly (bypassing libc/libdl
+ * Issue security-sensitive syscalls directly (bypassing libc/libdl
  *         hooks) to ensure that hook-based countermeasures cannot suppress
  *         detection results.
  *

--- a/runtime/android/elf_integrity.c
+++ b/runtime/android/elf_integrity.c
@@ -1,13 +1,13 @@
 /*===-- runtime/elf_integrity.c - ELF structure tampering detection --------===
  *
- * 4.3.2: Detects runtime ELF structure tampering on Android and Linux.
- * 4.3.13: Memory page permission check — detects W+X mapped pages.
+ * Detects runtime ELF structure tampering on Android and Linux.
+ * Memory page permission check — detects W+X mapped pages.
  *
  * Checks:
  *   1. Main executable ELF header magic / e_type sanity via /proc/self/exe.
  *   2. PT_LOAD segment flags via dl_iterate_phdr: any segment with both
  *      PF_W (write) and PF_X (execute) is a sign of runtime code injection.
- *   3. /proc/self/maps scan for rwx pages (4.3.13).
+ *   3. /proc/self/maps scan for rwx pages.
  *
  * Public API
  * ----------
@@ -89,7 +89,7 @@ void kagura_elf_integrity_check(void) {
 }
 
 /* -------------------------------------------------------------------------
- * Check 3 (4.3.13): /proc/self/maps scan for rwx pages
+ * Check 3: /proc/self/maps scan for rwx pages
  * ---------------------------------------------------------------------- */
 
 int kagura_wx_pages_present(void) {

--- a/runtime/android/jni_hook_detection.c
+++ b/runtime/android/jni_hook_detection.c
@@ -1,6 +1,6 @@
 /*===-- runtime/jni_hook_detection.c - JNI table hook detection -----------===
  *
- * 4.3.10: Detect JNI function table (JavaVM / JNIEnv) hooking.
+ * Detect JNI function table (JavaVM / JNIEnv) hooking.
  *
  * Hooking frameworks (e.g. YAHFA, SandHook, Epic) intercept JNI calls by
  * replacing function pointers in the JNIEnv or JavaVM vtables.  This module

--- a/runtime/android/load_order.c
+++ b/runtime/android/load_order.c
@@ -1,6 +1,6 @@
 /*===-- runtime/load_order.c - Native library load order control ----------===
  *
- * 4.4.17: Control native library load order on Android to ensure that
+ * Control native library load order on Android to ensure that
  *         kagura_runtime.so loads before third-party SDKs or game engines,
  *         and to verify that the expected set of libraries is present in the
  *         expected order.

--- a/runtime/android/play_integrity.c
+++ b/runtime/android/play_integrity.c
@@ -1,6 +1,6 @@
 /*===-- runtime/play_integrity.c - Play Integrity API integration ---------===
  *
- * 4.4.13: Android Play Integrity API integration.
+ * Android Play Integrity API integration.
  *
  * The Play Integrity API replaces the deprecated SafetyNet Attestation API
  * (deprecated June 2024, shutdown June 2025).  This module provides:

--- a/runtime/android/proc_inspection.c
+++ b/runtime/android/proc_inspection.c
@@ -1,6 +1,6 @@
 /*===-- runtime/proc_inspection.c - /proc filesystem hardening ------------===
  *
- * 4.4.12: Harden /proc/self/{maps,status,mounts,fd} inspection.
+ * Harden /proc/self/{maps,status,mounts,fd} inspection.
  *
  * On Android, security researchers use /proc/self/maps to enumerate loaded
  * libraries, /proc/self/status to detect ptrace attachment, and

--- a/runtime/android/safetynet_compat.c
+++ b/runtime/android/safetynet_compat.c
@@ -1,6 +1,6 @@
 /*===-- runtime/safetynet_compat.c - SafetyNet backward compatibility -----===
  *
- * 4.4.14: SafetyNet backward compatibility shim.
+ * SafetyNet backward compatibility shim.
  *
  * Google deprecated the SafetyNet Attestation API in June 2024 and announced
  * shutdown in June 2025.  This module provides:

--- a/runtime/android/seccomp_checks.c
+++ b/runtime/android/seccomp_checks.c
@@ -1,6 +1,6 @@
 /*===-- runtime/seccomp_checks.c - seccomp/prctl environment checks -------===
  *
- * 4.4.16: Detect seccomp/prctl sandbox environment indicators that may signal
+ * Detect seccomp/prctl sandbox environment indicators that may signal
  *         a security research or analysis environment on Android/Linux.
  *
  * Checks performed:

--- a/runtime/android/split_apk.c
+++ b/runtime/android/split_apk.c
@@ -1,6 +1,6 @@
 /*===-- runtime/split_apk.c - Split APK / AAB support --------------------===
  *
- * 4.4.18: Split APK and Android App Bundle (AAB) support.
+ * Split APK and Android App Bundle (AAB) support.
  *
  * When an app is delivered as a split APK or AAB, the APK file that
  * contains native libraries may be different from the base APK that holds

--- a/runtime/anti_debug/anti_dump.c
+++ b/runtime/anti_debug/anti_dump.c
@@ -1,6 +1,6 @@
 /*===-- runtime/anti_dump.c - Anti-dump / anti-memory-scan ---------------===
  *
- * 4.3.15: Anti-dump and anti-memory-scan countermeasures.
+ * Anti-dump and anti-memory-scan countermeasures.
  *
  * Memory dumping tools (dumpdecrypted, Fridump, mem-dump) extract the full
  * contents of a process's address space.  This module provides:

--- a/runtime/anti_debug/loaded_library_scan.c
+++ b/runtime/anti_debug/loaded_library_scan.c
@@ -1,6 +1,6 @@
 /*===-- runtime/loaded_library_scan.c - Suspicious loaded module detection -===
  *
- * 4.3.6: Scans the loaded dynamic libraries for known analysis / hooking
+ * Scans the loaded dynamic libraries for known analysis / hooking
  *         framework names on both iOS (Mach-O dyld image list) and Android
  *         (ELF dl_iterate_phdr).
  *

--- a/runtime/anti_debug/soft_response.c
+++ b/runtime/anti_debug/soft_response.c
@@ -1,6 +1,6 @@
 /*===-- runtime/soft_response.c - Delayed/soft anti-cheat response --------===
  *
- * 4.5.8: Delayed and graduated response to detected tampering.
+ * Delayed and graduated response to detected tampering.
  *
  * An immediate crash or ban on first detection:
  *   1. Teaches the attacker what triggers the protection.

--- a/runtime/anti_debug/symbol_interposition.c
+++ b/runtime/anti_debug/symbol_interposition.c
@@ -1,6 +1,6 @@
 /*===-- runtime/symbol_interposition.c - Symbol interposition detection ---===
  *
- * 4.3.8: Detect LD_PRELOAD / DYLD_INSERT_LIBRARIES symbol interposition.
+ * Detect LD_PRELOAD / DYLD_INSERT_LIBRARIES symbol interposition.
  *
  * When an attacker uses LD_PRELOAD (Linux/Android) or DYLD_INSERT_LIBRARIES
  * (Apple) to interpose symbols, the resolved address of a known function will

--- a/runtime/core/blob_integrity.c
+++ b/runtime/core/blob_integrity.c
@@ -1,6 +1,6 @@
 /*===-- runtime/blob_integrity.c - Checksum-guarded decryption ------------===
  *
- * 4.2.13: Compute and verify FNV-1a-32 checksums over encrypted blobs before
+ * Compute and verify FNV-1a-32 checksums over encrypted blobs before
  *         decryption to detect tampering with the binary at rest.
  *
  * If the checksum of the encrypted blob no longer matches the compile-time

--- a/runtime/core/crash_symbolication.c
+++ b/runtime/core/crash_symbolication.c
@@ -1,6 +1,6 @@
 /*===-- runtime/crash_symbolication.c - Crash symbolication support -------===
  *
- * 4.6.6: Crash symbolication support (dSYM / tombstone).
+ * Crash symbolication support (dSYM / tombstone).
  *
  * When kagura renames or moves functions/variables, stack traces in crash
  * reports become unreadable.  This module provides:

--- a/runtime/core/device_key.c
+++ b/runtime/core/device_key.c
@@ -1,6 +1,6 @@
 /*===-- runtime/device_key.c - Device-bound key derivation ----------------===
  *
- * 4.2.6: Derive encryption keys that are bound to the specific device,
+ * Derive encryption keys that are bound to the specific device,
  *        so that a string blob extracted from one device cannot be decrypted
  *        on a different device (e.g. by an attacker who dumped the APK/IPA).
  *

--- a/runtime/core/zero_buf.c
+++ b/runtime/core/zero_buf.c
@@ -1,6 +1,6 @@
 /*===-- runtime/zero_buf.c - Volatile memory zeroing helper ---------------===
  *
- * 4.2.5: Provides kagura_zero_buf(), called by decryption stubs injected by
+ * Provides kagura_zero_buf(), called by decryption stubs injected by
  * the StringEncryptionAES LLVM pass to clear the decrypted plaintext buffer
  * immediately after use.
  *

--- a/runtime/game/behavior_log.c
+++ b/runtime/game/behavior_log.c
@@ -1,6 +1,6 @@
 /*===-- runtime/behavior_log.c - Suspicious behavior logging --------------===
  *
- * 4.5.7: Collect and report suspicious cheat-indicative behaviors.
+ * Collect and report suspicious cheat-indicative behaviors.
  *
  * Rather than immediately banning on first detection, this module accumulates
  * suspicious event signals into a circular ring buffer.  The game can

--- a/runtime/game/game_values.c
+++ b/runtime/game/game_values.c
@@ -1,11 +1,11 @@
 /*===-- runtime/game_values.c - Game value protection helpers -------------===
  *
- * 4.5.12: Speed/movement value protection.
+ * Speed/movement value protection.
  *   Protect speed, velocity, and position values from memory manipulation
  *   by storing them as XOR-obfuscated pairs (value ^ key, key) and
  *   detecting tampering on each access.
  *
- * 4.5.13: Random seed protection.
+ * Random seed protection.
  *   Wrap the game's PRNG seed in an XOR-encrypted struct that detects when
  *   the seed has been patched to produce predictable outcomes (e.g. loot
  *   manipulation, aim randomness reduction).
@@ -16,13 +16,13 @@
  *
  * Public API
  * ----------
- * 4.5.12 — Speed protection:
+ * Speed protection:
  *   void    kagura_speed_init(kagura_speed_t *s, float value);
  *   float   kagura_speed_get(const kagura_speed_t *s);
  *   void    kagura_speed_set(kagura_speed_t *s, float value);
  *   int     kagura_speed_valid(const kagura_speed_t *s, float min, float max);
  *
- * 4.5.13 — Seed protection:
+ * Seed protection:
  *   void     kagura_seed_init(kagura_seed_t *s, uint64_t seed);
  *   uint64_t kagura_seed_get(const kagura_seed_t *s);
  *   void     kagura_seed_set(kagura_seed_t *s, uint64_t seed);
@@ -35,7 +35,7 @@
 
 extern void kagura_on_tamper_detected(void);
 
-/* ── 4.5.12: Protected floating-point value (speed / position / velocity) ─ */
+/* ── Protected floating-point value (speed / position / velocity) ─────── */
 
 typedef struct {
     uint32_t enc;   /* float bits XOR key */
@@ -82,7 +82,7 @@ int kagura_speed_valid(const kagura_speed_t *s, float min, float max) {
     return (v >= min && v <= max) ? 1 : 0;
 }
 
-/* ── 4.5.13: Protected PRNG seed ────────────────────────────────────────── */
+/* ── Protected PRNG seed ─────────────────────────────────────────────── */
 
 typedef struct {
     uint64_t enc;     /* seed ^ key */

--- a/runtime/game/integrity_report.c
+++ b/runtime/game/integrity_report.c
@@ -1,6 +1,6 @@
 /*===-- runtime/integrity_report.c - Integrity report signing + nonce ----===
  *
- * 4.5.9 + 4.5.10: Integrity report signing with replay prevention and
+ * Integrity report signing with replay prevention and
  *                  nonce / challenge-response for server coordination.
  *
  * Architecture

--- a/runtime/game/state_integrity.c
+++ b/runtime/game/state_integrity.c
@@ -1,6 +1,6 @@
 /*===-- runtime/state_integrity.c - Client-side state invariant checks ----===
  *
- * 4.5.5: State integrity check — verify that game-critical values satisfy
+ * State integrity check — verify that game-critical values satisfy
  *        compile-time-defined invariants at runtime.
  *
  * This module provides a generic invariant-check framework.  The game

--- a/runtime/ios/fishhook_countermeasure.c
+++ b/runtime/ios/fishhook_countermeasure.c
@@ -1,6 +1,6 @@
 /*===-- runtime/fishhook_countermeasure.c - fishhook rebinding detection --===
  *
- * 4.4.3: Detect fishhook-style GOT rebinding on Apple platforms.
+ * Detect fishhook-style GOT rebinding on Apple platforms.
  *
  * fishhook (and similar tools) walk the Mach-O __DATA,__got and
  * __DATA,__la_symbol_ptr sections and overwrite function pointer slots.

--- a/runtime/ios/ios_integrity.c
+++ b/runtime/ios/ios_integrity.c
@@ -1,10 +1,10 @@
 /*===-- runtime/ios_integrity.c - iOS code signing & ObjC swizzle detection ===
  *
- * 4.3.3: iOS code signing status verification.
- * 4.3.9: ObjC method swizzling detection.
- * 4.3.12: Hardware breakpoint detection (iOS/macOS side, moved here for grouping;
+ * iOS code signing status verification.
+ * ObjC method swizzling detection.
+ * Hardware breakpoint detection (iOS/macOS side, moved here for grouping;
  *          Linux side is in breakpoint_detection.c).
- * 4.3.13: Memory page W+X check on Apple platforms via vm_region_recurse_64.
+ * Memory page W+X check on Apple platforms via vm_region_recurse_64.
  *
  * Public API
  * ----------
@@ -30,7 +30,7 @@
 extern void kagura_tamper_detected(void);
 
 /* -------------------------------------------------------------------------
- * 4.3.3: Code signing status verification
+ * Code signing status verification
  *
  * Uses the csops(2) syscall (available on iOS and macOS) to query the
  * current process's code signing flags.  The CS_VALID flag (0x1) must be
@@ -76,7 +76,7 @@ void kagura_codesign_check(void) { }
 #endif /* TARGET_OS_IOS */
 
 /* -------------------------------------------------------------------------
- * 4.3.9: ObjC method swizzling detection
+ * ObjC method swizzling detection
  *
  * Uses the ObjC runtime to resolve the current IMP for (cls, sel) and
  * compares it against the expected_imp recorded at startup.  A mismatch
@@ -123,7 +123,7 @@ void kagura_objc_swizzle_check(void *cls, void *sel, void *imp)
 #endif /* TARGET_OS_IOS || TARGET_OS_OSX */
 
 /* -------------------------------------------------------------------------
- * 4.3.13 (Apple): W+X memory page detection via vm_region_recurse_64
+ * W+X memory page detection via vm_region_recurse_64
  *
  * Iterates the process's VM map looking for regions that are both writable
  * and executable.  This catches Substrate / libhooker style memory patches

--- a/runtime/ios/ios_jailbreak_advanced.c
+++ b/runtime/ios/ios_jailbreak_advanced.c
@@ -1,9 +1,9 @@
 /*===-- runtime/ios_jailbreak_advanced.c - Advanced iOS jailbreak detection ===
  *
- * 4.4.1: Jailbreak filesystem artifact detection (expanded path list).
- * 4.4.2: Cydia / Substrate / FridaGadget.dylib detection (dyld image scan
+ * Jailbreak filesystem artifact detection (expanded path list).
+ * Cydia / Substrate / FridaGadget.dylib detection (dyld image scan
  *         + path probes combined).
- * 4.3.14: App repackaging detection — checks that the bundle ID and code
+ * App repackaging detection — checks that the bundle ID and code
  *          signing team match the values baked in at compile time.
  *
  * These functions extend the basic checks in jailbreak_detection.c with
@@ -49,7 +49,7 @@ static int _ios_path_exists(const char *path) {
 }
 
 /* -------------------------------------------------------------------------
- * 4.4.1: Expanded jailbreak filesystem artifact detection
+ * Expanded jailbreak filesystem artifact detection
  *
  * Covers Cydia, Sileo, Zebra, Checkra1n, Unc0ver, Palera1n, Dopamine,
  * and the common tool-chain artifacts they install.
@@ -112,7 +112,7 @@ void kagura_jailbreak_fs_check(void) {
 }
 
 /* -------------------------------------------------------------------------
- * 4.4.2: Cydia / Substrate / FridaGadget detection
+ * Cydia / Substrate / FridaGadget detection
  *
  * Three-layer check:
  *   1. dyld image list scan (same as kagura_check_substrate_dylib in
@@ -180,7 +180,7 @@ void kagura_cydia_substrate_check(void) {
 }
 
 /* -------------------------------------------------------------------------
- * 4.3.14: App repackaging detection
+ * App repackaging detection
  *
  * Reads the bundle ID and team ID from the embedded mobile provision (or
  * from the Info.plist CF bundle identifier) at runtime and compares against

--- a/runtime/ios/ios_platform.c
+++ b/runtime/ios/ios_platform.c
@@ -1,8 +1,8 @@
 /*===-- runtime/ios_platform.c - iOS platform-specific protections --------===
  *
- * 4.4.6: iOS simulator exclusion (TARGET_OS_SIMULATOR).
- * 4.4.7: Entitlements verification (csops-based).
- * 4.4.9: dyld image list runtime inspection.
+ * iOS simulator exclusion (TARGET_OS_SIMULATOR).
+ * Entitlements verification (csops-based).
+ * dyld image list runtime inspection.
  *
  * Public API
  * ----------
@@ -24,7 +24,7 @@
 
 extern void kagura_on_tamper_detected(void);
 
-/* ── 4.4.6: Simulator detection ─────────────────────────────────────────── */
+/* ── Simulator detection ─────────────────────────────────────────────── */
 
 int kagura_is_simulator(void) {
 #if TARGET_OS_SIMULATOR
@@ -39,7 +39,7 @@ void kagura_simulator_check(void) {
         kagura_on_tamper_detected();
 }
 
-/* ── 4.4.7: Entitlements verification ──────────────────────────────────── */
+/* ── Entitlements verification ──────────────────────────────────────── */
 
 #if TARGET_OS_IOS && !TARGET_OS_SIMULATOR
 
@@ -75,7 +75,7 @@ void kagura_entitlements_check(void) {}
 
 #endif /* TARGET_OS_IOS */
 
-/* ── 4.4.9: dyld image list inspection ─────────────────────────────────── */
+/* ── dyld image list inspection ─────────────────────────────────────── */
 
 static const char *const kSuspiciousDylibs[] = {
     "FridaGadget",

--- a/runtime/ios/macho_integrity.c
+++ b/runtime/ios/macho_integrity.c
@@ -1,6 +1,6 @@
 /*===-- runtime/macho_integrity.c - Mach-O structure tampering detection --===
  *
- * 4.3.1: Detects runtime Mach-O header / load-command tampering on iOS and
+ * Detects runtime Mach-O header / load-command tampering on iOS and
  * macOS.  The following indicators are checked:
  *
  *   1. Load-command count mismatch — compare the ncmds field of the in-memory

--- a/runtime/ios/objc_name_remap.c
+++ b/runtime/ios/objc_name_remap.c
@@ -1,6 +1,6 @@
 /*===-- runtime/objc_name_remap.c - ObjC class/method name remap table ---===
  *
- * 4.2.3: ObjC class/method name obfuscation runtime support.
+ * ObjC class/method name obfuscation runtime support.
  *
  * The ObjCObfuscationPass obfuscates selector, class, property, and ivar
  * names at compile time.  However, code that performs dynamic lookups using

--- a/runtime/ios/swift_protection.c
+++ b/runtime/ios/swift_protection.c
@@ -1,6 +1,6 @@
 /*===-- runtime/swift_protection.c - Swift metadata countermeasures -------===
  *
- * 4.4.4: Swift metadata / demangling countermeasure.
+ * Swift metadata / demangling countermeasure.
  *
  * Swift's runtime exports extensive type metadata that reverse-engineering
  * tools (Ghidra, Hopper, class-dump-swift) use to reconstruct class

--- a/runtime/ios/testflight_detect.c
+++ b/runtime/ios/testflight_detect.c
@@ -1,6 +1,6 @@
 /*===-- runtime/testflight_detect.c - TestFlight vs App Store detection ---===
  *
- * 4.4.5: Differentiate between TestFlight and production App Store builds.
+ * Differentiate between TestFlight and production App Store builds.
  *
  * TestFlight builds have a sandboxReceipt file under the app bundle path,
  * while App Store builds have a regular receipt.  Security-sensitive code

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,7 +58,7 @@ kagura_add_pass_test(test_all_passes
   "kagura-str,kagura-fsplit,kagura-sv,function(kagura-bcf,kagura-sub,kagura-co,kagura-ibr,kagura-lt,kagura-bbr,kagura-bbs,kagura-dci)"
   combined_test.c)
 
-# ── New pass tests (Sprint 5 / 4.7.1) ────────────────────────────────────────
+# ── New pass tests ───────────────────────────────────────────────────────────
 kagura_add_pass_test(test_mvo
   "function(kagura-mvo)"
   arithmetic_test.c)
@@ -93,13 +93,13 @@ find_program(FILECHECK_EXECUTABLE NAMES FileCheck
   DOC "LLVM FileCheck"
 )
 
-# ---- 4.7.2 Integration tests ------------------------------------------------
+# ---- Integration tests ------------------------------------------------------
 add_subdirectory(integration)
 
-# ---- 4.7.5 Fuzz targets (only when KAGURA_BUILD_FUZZ=ON) -------------------
+# ---- Fuzz targets (only when KAGURA_BUILD_FUZZ=ON) --------------------------
 add_subdirectory(fuzz)
 
-# ---- 4.8.7 Regression corpus -----------------------------------------------
+# ---- Regression corpus ------------------------------------------------------
 add_subdirectory(regression)
 
 if(LIT_EXECUTABLE AND FILECHECK_EXECUTABLE)

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -1,4 +1,4 @@
-# 4.7.5: Fuzzing — libFuzzer-based crash detection for kagura passes.
+# Fuzzing — libFuzzer-based crash detection for kagura passes.
 #
 # Each fuzzer takes arbitrary bytes as input, interprets them as LLVM bitcode
 # (or a simplified IR representation), runs a kagura pass, and checks:

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,4 +1,4 @@
-# 4.7.2: Integration tests — compile a realistic "app" through kagura passes
+# Integration tests — compile a realistic "app" through kagura passes
 # and verify semantic correctness (output matches baseline) and binary size.
 #
 # Each integration test:

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -1,4 +1,4 @@
-# 4.8.7: Regression corpus — run each known-crash .ll file through the
+# Regression corpus — run each known-crash .ll file through the
 # relevant pass and verify it does NOT crash (exit 0).
 #
 # Each corpus entry is named crash_NNNNN.ll and has a companion

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -1,4 +1,4 @@
-# Regression Corpus (4.8.7)
+# Regression Corpus
 
 This directory contains a regression corpus of known-attack reproduction tests.
 Each test verifies that a specific past vulnerability or crash has been fixed

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-# kagura-opt: standalone bitcode processing tool (4.1.5 Bitcode input support)
+# kagura-opt: standalone bitcode processing tool
 #
 # Loads libKaguraObfuscator at runtime via PassPlugin::Load() — no static link
 # against the MODULE.  This avoids the MODULE_LIBRARY linkage restriction.


### PR DESCRIPTION
## Summary

- コメント・ドキュメント内の `4.x.x` 形式の実装フェーズ番号を全44ファイルから削除
- 機能の説明文はそのまま残し、番号プレフィックスのみ除去
- TODO.md の未実装項目の ID 列も `—` に統一