### PR TITLE
refactor: remove phase numbers from tests README headings

### DIFF
--- a/tests/decompiler_eval/README.md
+++ b/tests/decompiler_eval/README.md
@@ -1,4 +1,4 @@
-# Decompiler Resistance Evaluation (4.8.5)
+# Decompiler Resistance Evaluation
 
 Evaluates kagura's effectiveness against decompilers (Ghidra, IDA Pro,
 Binary Ninja) by measuring the quality of decompiled output on obfuscated

--- a/tests/frida_resistance/README.md
+++ b/tests/frida_resistance/README.md
@@ -1,4 +1,4 @@
-# Frida Script Resistance Evaluation (4.8.6)
+# Frida Script Resistance Evaluation
 
 This directory contains Frida scripts and evaluation tooling to test kagura's
 resistance against common Frida-based dynamic instrumentation attacks.

--- a/tests/redteam/README.md
+++ b/tests/redteam/README.md
@@ -1,4 +1,4 @@
-# Red-Team Evaluation Tooling (4.8.8)
+# Red-Team Evaluation Tooling
 
 This directory contains tooling for red-team assessments of kagura-protected
 binaries.  Use this to verify that kagura's protections are effective before

--- a/tests/symbolic_exec/README.md
+++ b/tests/symbolic_exec/README.md
@@ -1,4 +1,4 @@
-# Symbolic Execution Resistance Evaluation (4.8.4)
+# Symbolic Execution Resistance Evaluation
 
 Evaluates kagura's effectiveness against symbolic execution tools
 (angr, Triton, KLEE) by measuring analysis coverage on obfuscated vs.


### PR DESCRIPTION
## Summary

- `tests/redteam/README.md`、`tests/frida_resistance/README.md`、`tests/symbolic_exec/README.md`、`tests/decompiler_eval/README.md` の見出しから `(4.x.x)` 形式のフェーズ番号を削除
- #30 の作業漏れ分