### PR TITLE
Fix obfuscation pass correctness issues

### DIFF
--- a/lib/Transforms/AntiAnalysis/PointerAuth.cpp
+++ b/lib/Transforms/AntiAnalysis/PointerAuth.cpp
@@ -38,6 +38,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#define DEBUG_TYPE "kagura-pac"
+
 #include "kagura/Options.h"
 #include "kagura/Passes.h"
 #include "kagura/Utils.h"
@@ -506,3 +508,5 @@ PreservedAnalyses PointerAuthPass::run(Module &M, ModuleAnalysisManager &) {
 }
 
 } // namespace kagura
+
+#undef DEBUG_TYPE

--- a/lib/Transforms/CFG/FunctionSplit.cpp
+++ b/lib/Transforms/CFG/FunctionSplit.cpp
@@ -42,6 +42,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#define DEBUG_TYPE "kagura-fsplit"
+
 #include "kagura/Options.h"
 #include "kagura/Passes.h"
 #include "kagura/Utils.h"
@@ -54,6 +56,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/ValueMap.h"
+#include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 
@@ -340,3 +343,5 @@ PreservedAnalyses FunctionSplitPass::run(Module &M,
 }
 
 } // namespace kagura
+
+#undef DEBUG_TYPE

--- a/lib/Transforms/Data/PointerEncryption.cpp
+++ b/lib/Transforms/Data/PointerEncryption.cpp
@@ -7,9 +7,8 @@
 //   For each AllocaInst of a pointer type whose address does not escape the
 //   function:
 //     - At every StoreInst writing a pointer value, ptrtoint the pointer,
-//       XOR with the key, and store as i64.  (The alloca type is changed from
-//       ptr to i64.)
-//     - At every LoadInst reading from the alloca, load the i64, XOR with the
+//       XOR with the key, and store as the target's intptr width.
+//     - At every LoadInst reading from the alloca, load intptr, XOR with the
 //       key, and inttoptr back to the original pointer type.
 //
 // This makes it hard for memory dump analysis to follow raw pointer values from
@@ -34,6 +33,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Type.h"
+#include "llvm/IR/DataLayout.h"
 
 using namespace llvm;
 
@@ -74,8 +74,12 @@ PreservedAnalyses PointerEncryptionPass::run(Function &F,
   // function, so non-EH allocas are safe to transform.
 
   LLVMContext &Ctx = F.getContext();
-  auto *I64Ty  = Type::getInt64Ty(Ctx);
   auto *PtrTy  = PointerType::getUnqual(Ctx);
+  const DataLayout &DL = F.getParent()->getDataLayout();
+  unsigned PtrBits = DL.getPointerSizeInBits();
+  if (PtrBits == 0)
+    return PreservedAnalyses::all();
+  auto *IntPtrTy = Type::getIntNTy(Ctx, PtrBits);
 
   PRNG &RNG    = getModulePRNG();
   bool Changed = false;
@@ -97,9 +101,10 @@ PreservedAnalyses PointerEncryptionPass::run(Function &F,
   }
 
   for (auto *AI : Targets) {
-    uint64_t Key = RNG.next();
+    APInt Key(PtrBits, RNG.next());
 
-    // Change the alloca type to i64 (to store the XOR'd integer).
+    // The alloca remains a pointer-sized slot; loads/stores are rewritten to
+    // use the target's intptr width.
     AI->mutateType(PtrTy);          // alloca ptr type stays ptr (opaque)
     // We'll insert ptrtoint/xor/store and load/xor/inttoptr around uses.
 
@@ -114,16 +119,16 @@ PreservedAnalyses PointerEncryptionPass::run(Function &F,
         Loads.push_back(LI);
     }
 
-    auto *KeyConst = ConstantInt::get(I64Ty, Key);
+    auto *KeyConst = ConstantInt::get(IntPtrTy, Key);
 
-    // Rewrite stores: ptr -> ptrtoint -> xor -> store i64
+    // Rewrite stores: ptr -> ptrtoint -> xor -> store intptr
     for (auto *SI : Stores) {
       Value *Ptr = SI->getValueOperand();
       IRBuilder<> B(SI);
-      Value *AsInt    = B.CreatePtrToInt(Ptr, I64Ty, "pe.p2i");
+      Value *AsInt    = B.CreatePtrToInt(Ptr, IntPtrTy, "pe.p2i");
       Value *Encrypted = B.CreateXor(AsInt, KeyConst, "pe.enc");
       // Replace the store value with the encrypted integer.
-      // We need to store i64 — change the alloca to i64 for this alloca.
+      // We store the target's intptr width into the pointer-sized alloca slot.
       // Since the alloca stays opaque-ptr, just bitcast:
       auto *NewStore = B.CreateStore(Encrypted,
           B.CreateBitCast(AI, PointerType::getUnqual(Ctx)));
@@ -132,13 +137,13 @@ PreservedAnalyses PointerEncryptionPass::run(Function &F,
       Changed = true;
     }
 
-    // Rewrite loads: load i64 -> xor -> inttoptr
+    // Rewrite loads: load intptr -> xor -> inttoptr
     for (auto *LI : Loads) {
       Type *OrigTy = LI->getType();
       IRBuilder<> B(LI);
-      auto *LoadI64  = B.CreateLoad(I64Ty,
+      auto *LoadInt  = B.CreateLoad(IntPtrTy,
           B.CreateBitCast(AI, PointerType::getUnqual(Ctx)), "pe.raw");
-      Value *Decrypted = B.CreateXor(LoadI64, KeyConst, "pe.dec");
+      Value *Decrypted = B.CreateXor(LoadInt, KeyConst, "pe.dec");
       Value *AsPtr     = B.CreateIntToPtr(Decrypted, OrigTy, "pe.ptr");
       LI->replaceAllUsesWith(AsPtr);
       LI->eraseFromParent();

--- a/lib/Transforms/Data/StringEncryption.cpp
+++ b/lib/Transforms/Data/StringEncryption.cpp
@@ -184,6 +184,29 @@ static std::vector<GlobalVariable *> collectEncryptionTargets(Module &M) {
   return Result;
 }
 
+/// Return true when every use of GV can be rewritten at an instruction use
+/// site where the lazy-decrypt guard can be emitted.  Globals referenced from
+/// other global initializers are intentionally left alone: there is no runtime
+/// insertion point that can guarantee the encrypted bytes have been decrypted
+/// before the initializer-derived pointer is consumed.
+static bool hasOnlyGuardableUses(const GlobalVariable *GV) {
+  for (const User *U : GV->users()) {
+    if (isa<PHINode>(U))
+      return false;
+    if (isa<Instruction>(U))
+      continue;
+    if (isa<ConstantExpr>(U)) {
+      for (const User *Nested : U->users()) {
+        if (!isa<Instruction>(Nested) || isa<PHINode>(Nested))
+          return false;
+      }
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
 // ---- 4.2.4: Lazy decryption guard injection --------------------------------
 
 /// Emit the lazy-decrypt guard inline before Inst.
@@ -242,6 +265,9 @@ PreservedAnalyses StringEncryptionPass::run(Module &M,
   auto *Int8Ty = Type::getInt8Ty(Ctx);
 
   for (auto *GV : Strings) {
+    if (!hasOnlyGuardableUses(GV))
+      continue;
+
     auto *CDA = dyn_cast<ConstantDataArray>(GV->getInitializer());
     if (!CDA)
       continue;
@@ -290,8 +316,20 @@ PreservedAnalyses StringEncryptionPass::run(Module &M,
     SmallVector<User *, 8> Users(GV->users());
     for (auto *U : Users) {
       if (auto *CE = dyn_cast<ConstantExpr>(U)) {
-        CE->replaceAllUsesWith(
-            ConstantExpr::getBitCast(EncGV, CE->getType()));
+        SmallVector<User *, 8> CEUsers(CE->users());
+        for (auto *CU : CEUsers) {
+          auto *Inst = dyn_cast<Instruction>(CU);
+          if (!Inst || isa<PHINode>(Inst))
+            continue;
+
+          emitLazyGuard(Inst, FlagGV, Stub);
+
+          Value *Replacement = EncGV;
+          IRBuilder<> IB(Inst);
+          if (CE->getType() != EncGV->getType())
+            Replacement = IB.CreateBitCast(EncGV, CE->getType());
+          Inst->replaceUsesOfWith(CE, Replacement);
+        }
         continue;
       }
       if (auto *Inst = dyn_cast<Instruction>(U)) {
@@ -300,10 +338,6 @@ PreservedAnalyses StringEncryptionPass::run(Module &M,
         // uses here; they are reached from a non-PHI use site where the guard
         // will be inserted, or they are covered by the ConstantExpr path above.
         if (isa<PHINode>(Inst)) {
-          for (unsigned I = 0; I < Inst->getNumOperands(); ++I) {
-            if (Inst->getOperand(I)->stripPointerCasts() == GV)
-              Inst->setOperand(I, EncGV);
-          }
           continue;
         }
 

--- a/lib/Transforms/Data/StringEncryptionAES.cpp
+++ b/lib/Transforms/Data/StringEncryptionAES.cpp
@@ -7,11 +7,10 @@
 //   3. Replaces uses of the original global with a call to a per-string
 //      decryption stub that calls kagura_aes128_ctr_decrypt() at runtime.
 //
-// 4.2.5: Short-lived decrypted buffer (zero after use)
-//   The output buffer (kagura_aesbuf_<suffix>) is zeroed by injecting a call
-//   to kagura_zero_buf(ptr, len) immediately after the last use of the
-//   decrypted pointer in each basic block.  This minimises the window during
-//   which the plaintext is resident in memory.
+// 4.2.5: Short-lived decrypted buffer
+//   Each use site allocates a stack buffer and passes it to the per-string
+//   decrypt stub.  This avoids a shared mutable plaintext buffer and keeps the
+//   decrypted bytes scoped to the consuming function call frame.
 //
 // Registered as: -kagura-str-aes
 //
@@ -45,19 +44,6 @@ namespace kagura {
 //                                   const uint8_t nonce[8],
 //                                   uint8_t *out);
 //===----------------------------------------------------------------------===//
-
-// ---- 4.2.5: Zero-after-use runtime helper declaration ---------------------
-
-/// Declare kagura_zero_buf(void *ptr, uint32_t len) — provided by the runtime.
-/// Uses volatile semantics so the compiler cannot elide the zeroing.
-static FunctionCallee getOrDeclareZeroBuf(Module &M) {
-  LLVMContext &Ctx = M.getContext();
-  auto *VoidTy  = Type::getVoidTy(Ctx);
-  auto *PtrTy   = PointerType::getUnqual(Ctx);
-  auto *Int32Ty = Type::getInt32Ty(Ctx);
-  auto *FTy     = FunctionType::get(VoidTy, {PtrTy, Int32Ty}, false);
-  return M.getOrInsertFunction("kagura_zero_buf", FTy);
-}
 
 // ---- 4.2.13: Blob integrity check runtime declaration -------------------
 
@@ -105,7 +91,6 @@ static Function *buildAESDecryptStub(Module &M,
                                       GlobalVariable *EncGV,
                                       GlobalVariable *KeyGV,
                                       GlobalVariable *NonceGV,
-                                      GlobalVariable *OutBuf,
                                       uint64_t Len,
                                       uint32_t BlobChecksum,
                                       StringRef Suffix,
@@ -117,12 +102,13 @@ static Function *buildAESDecryptStub(Module &M,
   auto *Int32Ty = Type::getInt32Ty(Ctx);
   auto *PtrTy   = PointerType::getUnqual(Ctx);
 
-  // i8* kagura_aesdec_<suffix>()
-  auto *FTy = FunctionType::get(PtrTy, false);
+  // i8* kagura_aesdec_<suffix>(i8* out)
+  auto *FTy = FunctionType::get(PtrTy, {PtrTy}, false);
   auto *F   = Function::Create(FTy, Function::InternalLinkage,
                                "kagura_aesdec_" + Suffix, M);
   F->addFnAttr(Attribute::NoInline);
   F->addFnAttr(Attribute::NoUnwind);
+  F->getArg(0)->setName("out");
 
   auto *Entry = BasicBlock::Create(Ctx, "entry", F);
   B.SetInsertPoint(Entry);
@@ -130,7 +116,7 @@ static Function *buildAESDecryptStub(Module &M,
   auto *EncPtr   = B.CreateBitCast(EncGV,  PtrTy, "enc");
   auto *KeyPtr   = B.CreateBitCast(KeyGV,  PtrTy, "key");
   auto *NoncePtr = B.CreateBitCast(NonceGV, PtrTy, "nonce");
-  auto *OutPtr   = B.CreateBitCast(OutBuf,  PtrTy, "out");
+  auto *OutPtr   = F->getArg(0);
 
   // 4.2.13: Verify blob integrity before decrypting.
   B.CreateCall(BlobIntegrityCheck,
@@ -147,6 +133,32 @@ static Function *buildAESDecryptStub(Module &M,
 
   B.CreateRet(OutPtr);
   return F;
+}
+
+static Value *emitAESDecryptCall(IRBuilder<> &B, Function *Stub,
+                                 ArrayType *OutArrTy) {
+  auto *OutBuf = B.CreateAlloca(OutArrTy, nullptr, "kagura.aesbuf");
+  auto *PtrTy = PointerType::getUnqual(B.getContext());
+  Value *OutPtr = B.CreateBitCast(OutBuf, PtrTy);
+  return B.CreateCall(Stub, {OutPtr}, "aesdec");
+}
+
+static bool hasOnlyGuardableUses(const GlobalVariable *GV) {
+  for (const User *U : GV->users()) {
+    if (isa<PHINode>(U))
+      return false;
+    if (isa<Instruction>(U))
+      continue;
+    if (isa<ConstantExpr>(U)) {
+      for (const User *Nested : U->users()) {
+        if (!isa<Instruction>(Nested) || isa<PHINode>(Nested))
+          return false;
+      }
+      continue;
+    }
+    return false;
+  }
+  return true;
 }
 
 //===----------------------------------------------------------------------===//
@@ -169,6 +181,9 @@ PreservedAnalyses StringEncryptionAESPass::run(Module &M,
   auto *Int8Ty = Type::getInt8Ty(Ctx);
 
   for (auto *GV : Strings) {
+    if (!hasOnlyGuardableUses(GV))
+      continue;
+
     auto *CDA = cast<ConstantDataArray>(GV->getInitializer());
     StringRef Raw = CDA->getRawDataValues();
     uint64_t Len  = Raw.size();
@@ -208,25 +223,17 @@ PreservedAnalyses StringEncryptionAESPass::run(Module &M,
       auto *NonceGV = createPrivateByteGlobal(
           M, ArrayRef<uint8_t>(Nonce, 8), "kagura_aesnonce_" + Suffix);
 
-      // 4.2.5: Static output buffer — declared here so we can zero it later.
       auto *OutArrTy = ArrayType::get(Int8Ty, Len);
-      auto *OutBuf   = new GlobalVariable(
-          M, OutArrTy, /*isConstant=*/false, GlobalValue::PrivateLinkage,
-          ConstantAggregateZero::get(OutArrTy),
-          "kagura_aesbuf_" + Suffix);
 
       // Build per-string decryption stub
-      Function *Stub = buildAESDecryptStub(M, EncGV, KeyGV, NonceGV, OutBuf,
+      Function *Stub = buildAESDecryptStub(M, EncGV, KeyGV, NonceGV,
                                            Len, BlobChecksum, Suffix,
                                            RuntimeDecrypt, BlobIntegrity);
 
-      // 4.2.5: Declare zero helper once per module.
-      FunctionCallee ZeroBuf = getOrDeclareZeroBuf(M);
-      auto *Int32Ty = Type::getInt32Ty(Ctx);
-      auto *PtrTy   = PointerType::getUnqual(Ctx);
-
       // Replace uses of the original global.
-      // Track all call results so we can insert zero-after-use.
+      // Each use gets a per-call stack buffer.  This avoids the static shared
+      // buffer races and the incorrect immediate zeroing that broke stored or
+      // returned decrypted pointers.
       SmallVector<User *, 8> Users(GV->users());
       for (auto *U : Users) {
         if (auto *CE = dyn_cast<ConstantExpr>(U)) {
@@ -234,28 +241,21 @@ PreservedAnalyses StringEncryptionAESPass::run(Module &M,
           for (auto *CU : CEUsers) {
             if (auto *Inst = dyn_cast<Instruction>(CU)) {
               IRBuilder<> IB(Inst);
-              Value *DecPtr = IB.CreateCall(Stub, {}, "aesdec");
+              Value *DecPtr = emitAESDecryptCall(IB, Stub, OutArrTy);
               Value *Replacement = DecPtr;
               if (CE->getType() != DecPtr->getType())
                 Replacement = IB.CreateBitCast(DecPtr, CE->getType());
               Inst->replaceUsesOfWith(CE, Replacement);
-
-              // 4.2.5: zero immediately after the instruction that consumed
-              // the decrypted pointer (best-effort; covers the common case).
-              if (Instruction *NextI = Inst->getNextNode()) {
-                IRBuilder<> ZB(NextI);
-                ZB.CreateCall(ZeroBuf, {
-                    ZB.CreateBitCast(OutBuf, PtrTy),
-                    ConstantInt::get(Int32Ty, static_cast<uint32_t>(Len))});
-              }
             }
           }
           continue;
         }
 
         if (auto *Inst = dyn_cast<Instruction>(U)) {
+          if (isa<PHINode>(Inst))
+            continue;
           IRBuilder<> IB(Inst);
-          Value *DecPtr = IB.CreateCall(Stub, {}, "aesdec");
+          Value *DecPtr = emitAESDecryptCall(IB, Stub, OutArrTy);
           for (unsigned I = 0; I < Inst->getNumOperands(); ++I) {
             if (Inst->getOperand(I)->stripPointerCasts() == GV) {
               Value *Replacement = DecPtr;
@@ -264,13 +264,6 @@ PreservedAnalyses StringEncryptionAESPass::run(Module &M,
                     IB.CreateBitCast(DecPtr, Inst->getOperand(I)->getType());
               Inst->setOperand(I, Replacement);
             }
-          }
-          // 4.2.5: zero buffer right after the use-site instruction.
-          if (Instruction *NextI = Inst->getNextNode()) {
-            IRBuilder<> ZB(NextI);
-            ZB.CreateCall(ZeroBuf, {
-                ZB.CreateBitCast(OutBuf, PtrTy),
-                ConstantInt::get(Int32Ty, static_cast<uint32_t>(Len))});
           }
         }
       }


### PR DESCRIPTION
Fixes
  kagura-opt option parsing/plugin discovery, string encryption unsafe uses, pointer-width handling, AES
  decrypted buffer lifetime, and clean-build DEBUG_TYPE errors.