### PR TITLE
docs(mkdocs): collapsible left-sidebar nav with subsections

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,29 +38,21 @@ Kagura addresses this at the IR level — before the compiler turns IR into mach
 
     Reference for every IR pass — flags, effects, code-size and runtime overhead.
 
-- :material-cog: **[Configuration](configuration.md)**
-
-    JSON policy DSL, strength profiles, tuning parameters, per-function annotations.
-
-- :material-shield-lock: **[Game Protection](game-protection.md)**
-
-    `Protected<T>` template for HP, currency, and other anti-cheat-sensitive values.
-
 - :material-toolbox: **[Integration](integration/index.md)**
 
     Xcode, Gradle/NDK, Unity, Unreal, CMake, Bazel, CocoaPods, SPM.
 
-- :material-test-tube: **[Testing & Evaluation](testing.md)**
+- :material-cog: **[Configuration](configuration.md)** · **[Tuning](tuning.md)** · **[Pass Order](pass-order.md)**
 
-    Differential testing, reproducible builds, angr / Ghidra / Frida resistance.
+    JSON policy DSL, strength profiles, CLI flags, and the deterministic pipeline.
 
-- :material-server: **[Runtime Library](runtime.md)**
+- :material-shield-lock: **[Game Protection](game-protection.md)** · **[Runtime Library](runtime.md)**
 
-    Symbols required by each pass, anti-tamper API, callable checks.
+    `Protected<T>` for HP/currency, plus runtime anti-tamper API.
 
-- :material-format-list-numbered: **[Pass Order](pass-order.md)**
+- :material-test-tube: **[Testing](testing.md)** · **[Architecture](architecture.md)** · **[Contributing](contributing.md)**
 
-    The deterministic pipeline the plugin registers with `OptimizerLast`.
+    Differential / reproducible tests, source layout, contributor workflow.
 
 </div>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ Kagura addresses this at the IR level — before the compiler turns IR into mach
 
 <div class="grid cards" markdown>
 
-- :material-rocket-launch: **[Getting Started](getting-started/quick-start.md)**
+- :material-rocket-launch: **[Getting Started](getting-started/index.md)**
 
     Install, build, and run your first obfuscated binary in under five minutes.
 
@@ -42,17 +42,17 @@ Kagura addresses this at the IR level — before the compiler turns IR into mach
 
     Xcode, Gradle/NDK, Unity, Unreal, CMake, Bazel, CocoaPods, SPM.
 
-- :material-cog: **[Configuration](configuration.md)** · **[Tuning](tuning.md)** · **[Pass Order](pass-order.md)**
+- :material-cog: **[Configuration](configuration.md)**
 
-    JSON policy DSL, strength profiles, CLI flags, and the deterministic pipeline.
+    JSON policy DSL, strength profiles, CLI tuning parameters, deterministic pass order.
 
-- :material-shield-lock: **[Game Protection](game-protection.md)** · **[Runtime Library](runtime.md)**
+- :material-shield-lock: **[Runtime](runtime.md)**
 
-    `Protected<T>` for HP/currency, plus runtime anti-tamper API.
+    Anti-tamper API and `Protected<T>` for HP / currency / game-state values.
 
-- :material-test-tube: **[Testing](testing.md)** · **[Architecture](architecture.md)** · **[Contributing](contributing.md)**
+- :material-test-tube: **[Project](testing.md)**
 
-    Differential / reproducible tests, source layout, contributor workflow.
+    Testing & evaluation, architecture, contributor workflow.
 
 </div>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,11 +21,12 @@ theme:
         icon: material/brightness-4
         name: Switch to light mode
   features:
-    - navigation.tabs
-    - navigation.sections
     - navigation.indexes
     - navigation.top
     - navigation.footer
+    - navigation.instant
+    - navigation.tracking
+    - toc.follow
     - search.highlight
     - search.suggest
     - content.code.copy
@@ -83,12 +84,14 @@ nav:
       - Bazel: integration/bazel.md
       - CocoaPods: integration/cocoapods.md
       - Swift Package Manager: integration/swiftpm.md
-  - Reference:
-      - Configuration: configuration.md
+  - Configuration:
+      - Overview: configuration.md
       - Tuning Parameters: tuning.md
       - Pass Order: pass-order.md
+  - Runtime:
       - Runtime Library: runtime.md
       - Game Protection: game-protection.md
+  - Project:
       - Testing & Evaluation: testing.md
       - Architecture: architecture.md
       - Contributing: contributing.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,12 +73,6 @@ nav:
       - Infrastructure: passes/infrastructure.md
       - Before / After Examples: passes/before-after.md
       - Performance & Size Impact: passes/performance.md
-  - Configuration:
-      - configuration.md
-      - Pass Order: pass-order.md
-      - Tuning Parameters: tuning.md
-  - Game Protection: game-protection.md
-  - Runtime Library: runtime.md
   - Integration:
       - integration/index.md
       - Xcode: integration/xcode.md
@@ -89,7 +83,12 @@ nav:
       - Bazel: integration/bazel.md
       - CocoaPods: integration/cocoapods.md
       - Swift Package Manager: integration/swiftpm.md
-  - Testing & Evaluation:
-      - testing.md
-  - Architecture: architecture.md
-  - Contributing: contributing.md
+  - Reference:
+      - Configuration: configuration.md
+      - Tuning Parameters: tuning.md
+      - Pass Order: pass-order.md
+      - Runtime Library: runtime.md
+      - Game Protection: game-protection.md
+      - Testing & Evaluation: testing.md
+      - Architecture: architecture.md
+      - Contributing: contributing.md


### PR DESCRIPTION
## Summary

Top tab bar was crowded with 10 tabs. Rework navigation to be a **left sidebar only**, with collapsible grouped sections.

### Before
- 10 horizontal tabs across the top (Home, Getting Started, Passes, Configuration, Game Protection, Runtime, Integration, Testing, Architecture, Contributing)
- All children always expanded; no grouping

### After
- No top tabs — everything in the left sidebar
- 6 collapsible groups (with ▸ click-to-expand):
  - **Getting Started**: Quick Start / Build from Source / Requirements
  - **Passes**: Control Flow / Data / Anti-Analysis / Platform / Infrastructure / Before-After / Performance
  - **Integration**: Xcode / Android / Unity / Unreal / CMake / Bazel / CocoaPods / SPM
  - **Configuration**: Overview / Tuning Parameters / Pass Order
  - **Runtime**: Runtime Library / Game Protection
  - **Project**: Testing & Evaluation / Architecture / Contributing
- `toc.follow`, `navigation.instant`, `navigation.tracking` enabled for smoother in-page navigation

`docs/index.md` landing-page card grid also updated to mirror the new top-level grouping.

## Test plan

- [ ] `mkdocs build --strict` passes (validated by Docs CI on this PR)
- [ ] Sidebar renders 6 collapsible groups at https://ykus4.github.io/kagura after merge
- [ ] Current-page group auto-expands; other groups start collapsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)