### PR TITLE
ci(windows): bump LLVM 19.1.7 -> 21.1.5 for MSVC STL requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,10 @@ jobs:
   # GitHub releases, which includes the full dev tree (cmake files, headers,
   # import libs).  Version coverage across 17-22 is provided by the macOS
   # matrix; we use a recent stable version here.
+  #
+  # Note: the MSVC STL on windows-latest now requires Clang >= 20 (`error
+  # STL1000: Unexpected compiler version, expected Clang 20 or newer`), so we
+  # use LLVM 21.x rather than 19.x here.
   windows-msvc:
     name: Build & Test (Windows, Clang-CL)
     runs-on: windows-latest
@@ -71,7 +75,7 @@ jobs:
         run: |
           # The win64.exe installer is binaries-only; the full dev tree
           # (headers, cmake configs, import libs) is in the MSVC tarball.
-          $ver = "19.1.7"
+          $ver = "21.1.5"
           $url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-${ver}/clang+llvm-${ver}-x86_64-pc-windows-msvc.tar.xz"
           $archive = "$env:TEMP\llvm-dev.tar.xz"
           $dest    = "C:\llvm-dev"


### PR DESCRIPTION
## Summary

The `Build & Test (Windows, Clang-CL)` job has been failing on `main` since the latest `windows-latest` runner image picked up an MSVC STL update that asserts a minimum Clang version:

```
error STL1000: Unexpected compiler version, expected Clang 20 or newer.
```

This blocks build before any kagura source is touched (fails on `<cstddef>`).

## Fix

Bump the LLVM tarball we download for the Windows job from **19.1.7 → 21.1.5**. The macOS matrix already covers LLVM 17/18/19/21/22, so version coverage isn't reduced — Windows is a single representative version only.

## Test plan

- [ ] CI green on `Build & Test (Windows, Clang-CL)` for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)