### PR TITLE
docs(batch-b): security model + cookbook recipes

### DIFF
--- a/docs/cookbook/banking.md
+++ b/docs/cookbook/banking.md
@@ -1,0 +1,170 @@
+# Banking / FinTech
+
+Protect transaction-signing keys, certificate pins, and authentication flows
+against on-device analysis. The goal isn't perfect secrecy — that belongs
+server-side — it's raising attacker cost above the economic threshold for
+fraud-scale automation.
+
+## Threat model
+
+| Asset | Adversary | Capability |
+|:------|:----------|:-----------|
+| HMAC / signing keys | Mobile malware, rooted-device fraud rings | Static extraction, memory dump |
+| Certificate pin list | MITM proxies (mitmproxy, Charles, Burp) | Static string search, runtime patching |
+| Anti-fraud heuristics | Reverse engineers building bypass kits | Decompile + write a generator that mimics legitimate traffic |
+| Session token handling | Frida / Substrate scripts | Hook the request signer to log tokens |
+
+See [Security Model](../security-model.md) for what Kagura can and cannot do
+in this scenario. Spoiler: this is **defense in depth** — Kagura is one layer.
+
+## Policy file
+
+```json title="kagura-bank.json"
+{
+  "profile": "STRONG",
+  "passes": {
+    "str-aes":  true,
+    "wstr":     true,
+    "mvo":      true,
+    "pe":       true,
+    "co":       true,
+    "fla":      true,
+    "bcf":      true,
+    "sub":      true,
+    "bbcheck":  true,
+    "tamper":   true,
+    "anti-debug": true,
+    "ci":       true,
+    "sv":       true,
+    "honey":    true
+  },
+  "tuning": {
+    "bcf_prob": 60,
+    "seed":     0
+  }
+}
+```
+
+Why these choices:
+
+- **`str-aes` + `wstr`** — encrypt all string literals (Swift `String`,
+  Objective-C `@""`, Kotlin / Java string constants pulled into JNI) so
+  `strings` returns nothing useful
+- **`mvo` + `pe`** — on-stack key buffers and pointers stay XOR-encrypted at
+  every store/load, even after the function uses them
+- **`co` + `sub`** — break MBA pattern matchers (de4dot, FLOSS) on inline
+  constants
+- **`fla` + `bcf`** with `bcf_prob: 60` — defeats Ghidra's CFG view in
+  decompiler-resistant builds
+- **`bbcheck` + `tamper`** — catches binary patching attempts at every BB
+- **`anti-debug`** — drops the obvious "Cheat Engine attached as debugger"
+  attacks
+- **`ci`** — hides imports from IDA's Import View
+- **`sv`** — strips non-public symbols so the dynamic symtab doesn't leak
+  internal names
+- **`honey`** — injects decoy globals (`g_api_key_v2`, etc.) and fake stubs
+
+## Build
+
+```bash
+# Per-release key rotation: a key extracted from v1 doesn't decrypt v2 strings
+clang -fpass-plugin=KaguraObfuscator.dylib \
+      -mllvm -kagura-config=kagura-bank.json \
+      -mllvm -kagura-build-id=$(git rev-parse HEAD) \
+      -mllvm -kagura-symmap \
+      -mllvm -kagura-symmap-out=bank-symmap-$(git describe).json \
+      -O2 -c bank_core.c -o bank_core.o
+```
+
+Keep the `bank-symmap-<release>.json` files **off-device** — they let you
+symbolicate crash reports without shipping debug symbols.
+
+## Source-side annotations
+
+Mark the highest-value functions for VM virtualization:
+
+```c
+#include "kagura/runtime.h"
+
+// Sign a transaction request. Worth the 10–50× VM overhead — called once per
+// payment, but a 100% guarantee that this code is never readable as
+// native instructions.
+__attribute__((annotate("kagura_vm")))
+int sign_transaction(const uint8_t *payload, size_t len, uint8_t out[64]) {
+    // ... HMAC-SHA256 implementation
+}
+
+// Hot path — keep BALANCED-equivalent. Don't VM this.
+__attribute__((annotate("kagura_nofla")))
+int validate_amount(int64_t amount) { return amount > 0 && amount < 1e9; }
+```
+
+## Runtime hardening
+
+In your application's startup path:
+
+```c
+#include "kagura/runtime.h"
+
+int app_init(void) {
+    // 1. Refuse to run on a tampered binary
+    if (kagura_self_check() != 0) {
+        // Don't abort() — soft-respond so the detection point isn't a
+        // tombstone an attacker can grep for in /var/mobile/Library/Logs.
+        return -1;
+    }
+
+    // 2. Refuse to run with Frida / Substrate loaded
+    if (kagura_check_loaded_libraries() != 0) {
+        return -1;
+    }
+
+    // 3. Refuse to run on jailbroken / rooted devices for payment flows.
+    //    (Use feature-gated UX; do not crash the app for non-payment flows.)
+    extern int kagura_jailbreak_check(void);  // iOS
+    extern int kagura_root_check(void);       // Android
+    if (kagura_jailbreak_check() || kagura_root_check()) {
+        // Disable payment UI; show a "not supported on this device" screen.
+    }
+
+    return 0;
+}
+```
+
+## Verification
+
+Before shipping, run all of:
+
+```bash
+# 1. No plaintext API keys in the binary
+strings YourApp.app/YourApp | grep -iE "api_key|hmac|secret"
+# Should return nothing.
+
+# 2. No readable signing logic
+ghidra YourApp.app/YourApp     # then run the Ghidra eval suite
+cd tests/decompiler_eval && python3 run_ghidra_eval.py \
+    --binary YourApp.app/YourApp --ghidra /path/to/ghidra
+
+# 3. Frida resistance
+cd tests/frida_resistance
+for s in probes/F*.js; do frida -l "$s" -f YourApp.app/YourApp; done
+
+# 4. App Store review risk assessment
+./scripts/review-risk-assessment.sh YourApp.app/YourApp --platform ios
+
+# 5. Confirm the release build actually obfuscated what you asked for
+./scripts/kagura-diff.py baseline.dylib release.dylib --html report.html
+```
+
+## What's still on you
+
+Kagura cannot:
+
+- Protect a key that **must** survive a memory dump — put it in the
+  platform keystore (Keychain / Android Keystore / SE / StrongBox)
+- Make rooted / jailbroken devices safe for high-value transactions —
+  combine with Apple DeviceCheck / App Attest or Android Play Integrity
+- Replace server-side fraud detection — Kagura raises client-side cost; the
+  server still needs to detect anomalous patterns
+
+See [Security Model](../security-model.md) for the full boundary.

--- a/docs/cookbook/drm.md
+++ b/docs/cookbook/drm.md
@@ -1,0 +1,196 @@
+# DRM / license enforcement
+
+Hide license-check logic so it's never readable as native code, even under
+a debugger. This is the classic anti-piracy use case — your goal is to make
+"crack the check" cost more than the price of a legitimate license.
+
+## Threat model
+
+| Asset | Adversary | Capability |
+|:------|:----------|:-----------|
+| License-validation function | Crackers | Decompile → find the `return 0` patch site |
+| Trial-period timer | End users | Roll back the system clock, NOP the date check |
+| Key-derivation function | Keygen authors | Reverse the algorithm, build a keygen |
+| Server-callback URL | Re-distribution sites | Replace with a mock server that always returns "licensed" |
+
+This is one of the **best-fit scenarios** for Kagura — license checks are
+cold paths, called once or twice per session, so the 10–50× VM slowdown is
+invisible to the user.
+
+## Policy file
+
+```json title="kagura-drm.json"
+{
+  "profile": "STRONG",
+  "passes": {
+    "str-aes":  true,
+    "wstr":     true,
+    "co":       true,
+    "fla":      true,
+    "bcf":      true,
+    "sub":      true,
+    "mvo":      true,
+    "pe":       true,
+    "genc":     true,
+    "ci":       true,
+    "sv":       true,
+    "honey":    true,
+    "bbcheck":  true,
+    "tamper":   true,
+    "anti-debug": true
+  },
+  "tuning": {
+    "bcf_prob": 60,
+    "seed":     0
+  }
+}
+```
+
+Everything STRONG plus `bbcheck` + `tamper` because:
+
+- A DRM binary's most common attack is `bsdiff` patching ("set `eax, 0`")
+- `bbcheck` detects per-BB modification at runtime
+- `tamper` catches whole-function modification at startup
+
+## Virtualize the license check
+
+This is the **key recipe** for DRM. Any function annotated with
+`kagura_vm` is compiled to a custom stack-based VM bytecode and removed
+from the binary as native code — the attacker sees an interpreter loop, not
+your algorithm.
+
+```c
+#include "kagura/runtime.h"
+
+// The crown jewel — compiled to VM bytecode. The attacker who decompiles
+// the binary sees: opaque byte array + interpreter call.  They have to
+// reverse the *interpreter* (not your function) before they can even start
+// reversing your function.
+__attribute__((annotate("kagura_vm")))
+int verify_license(const char *key, time_t now, uint64_t *out_expiry) {
+    // 1. Parse the license token format
+    if (!key || !*key) return -1;
+
+    // 2. HMAC the device fingerprint
+    uint8_t digest[32];
+    hmac_sha256(device_fingerprint(), 16, key, strlen(key), digest);
+
+    // 3. Compare against the embedded public key signature
+    if (!ed25519_verify(digest, signature_from(key), public_key)) {
+        return -1;
+    }
+
+    // 4. Extract expiry, validate not-in-future-not-in-past
+    uint64_t exp = expiry_from(key);
+    if (now > exp) return -1;
+    if (now < embedded_min_timestamp()) return -1;  // anti-rollback
+
+    *out_expiry = exp;
+    return 0;
+}
+
+// Also virtualize the trial-period check
+__attribute__((annotate("kagura_vm")))
+int check_trial_period(time_t install_date, time_t now) {
+    return (now - install_date) < (30 * 86400) ? 0 : -1;
+}
+```
+
+Other functions stay native (BALANCED+obfuscation only) — VM-virtualizing
+hot paths kills performance.
+
+## Anti-rollback for trial periods
+
+System-clock manipulation is the easiest piracy method. Defenses (combine
+several):
+
+```c
+// 1. Embed a monotonic "build timestamp" — the current time must be ≥ this
+__attribute__((annotate("kagura_vm")))
+time_t embedded_min_timestamp(void) {
+    return BUILD_TIMESTAMP;  // injected at build time via -DBUILD_TIMESTAMP=…
+}
+
+// 2. Keep a hidden "last seen" file (write XOR-encrypted bytes to a path
+//    the user doesn't easily find)
+__attribute__((annotate("kagura_vm")))
+time_t last_seen_timestamp(void) {
+    // read from ~/Library/.cache/.system_state (macOS)
+    // or  /var/data/data/<app>/cache/.sys (Android)
+    // XOR-decrypted with a per-install key derived from device_fingerprint()
+}
+
+// 3. Detect rollback: now < max(last_seen, build_min)
+if (now < max(last_seen_timestamp(), embedded_min_timestamp())) {
+    return -1;  // clock rollback attempt
+}
+```
+
+## Soft response
+
+Crashing on detection is bad — users with corrupted disks / weird system
+clocks file support tickets. Instead, **silently degrade**:
+
+```c
+int app_startup(void) {
+    if (kagura_self_check() != 0) {
+        // Don't crash. Just go into "limited" mode:
+        //   - Save to disk every 30s with a 50% chance of "I/O error"
+        //   - Random 200ms hitches every 10s
+        //   - Some menu items mysteriously do nothing
+        g_app_mode = APP_MODE_LIMITED;
+        return 0;
+    }
+
+    if (kagura_check_breakpoints() != 0) {
+        // Debug-attached. Don't crash, but compute results from a poisoned
+        // RNG so a cracker's "step through and see what happens" session
+        // produces nondeterministic garbage.
+        seed_rng_with_poison();
+    }
+
+    return 0;
+}
+```
+
+## Verification
+
+```bash
+# 1. verify_license() is gone as native code
+otool -tv YourApp | grep -A50 "_verify_license"
+# Should be empty or just a thunk into the VM interpreter
+
+# 2. No plaintext license format strings
+strings YourApp | grep -iE "license|expired|trial"
+# Should be empty
+
+# 3. Patching the obvious "return 0" sites doesn't bypass anything
+#    (Use the angr suite — it's the closest automated equivalent of a
+#     determined cracker.)
+cd tests/symbolic_exec && python3 run_angr_eval.py \
+    --binary YourApp --timeout 600 --target verify_license
+
+# 4. Frida script that tries to hook verify_license() finds nothing
+cat > frida_hook.js << 'EOF'
+Interceptor.attach(Module.findExportByName(null, "verify_license"), {
+    onEnter(args) { console.log("verify_license called"); },
+    onLeave(retval) { retval.replace(0); }  // force "licensed"
+});
+EOF
+frida -l frida_hook.js -f YourApp
+# Should print "Module.findExportByName: cannot find verify_license"
+# because kagura-sv hid the symbol
+```
+
+## What's still on you
+
+- **A skilled cracker with two weeks** will get through. The goal is **deter
+  casual cracking** and **slow professional cracking enough that a release
+  cycle ships before the crack does**.
+- **Server-side license validation** is strictly better than client-side.
+  Even one server callback per session (silently failing offline for legit
+  users) breaks most pirate distribution.
+- **DMCA / legal action** against re-distribution sites is the only
+  enforcement that scales. Technical measures are deterrents, not stops.
+- **No DRM is invisible.** If your app needs to load license-checked
+  content, the content is loaded somewhere. Plan for that.

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -1,0 +1,21 @@
+# Cookbook
+
+Practical, copy-pasteable recipes for common deployment scenarios.
+
+| Scenario | What you'll get |
+|:---------|:----------------|
+| [**Banking / FinTech**](banking.md) | Protect HMAC keys, certificate pins, transaction-signing logic |
+| [**Mobile game / anti-cheat**](mobile-game.md) | Hide HP / currency / speed from memory editors; respond to Frida |
+| [**SDK / library vendor**](sdk-vendor.md) | Ship a `.a` / `.so` consumers can link without changing their build |
+| [**DRM / license enforcement**](drm.md) | Virtualize license-check functions so they're never readable as native code |
+
+Each recipe shows:
+
+1. The threat model for that scenario
+2. A complete `kagura.json` policy
+3. Build commands
+4. Verification steps you can run yourself
+
+If you're not sure which one fits, start with the
+[Security Model](../security-model.md) page to figure out your threat model
+first.

--- a/docs/cookbook/mobile-game.md
+++ b/docs/cookbook/mobile-game.md
@@ -1,0 +1,158 @@
+# Mobile game / anti-cheat
+
+Hide game-state values (HP, currency, speed, ammo) from memory editors and
+respond to scripted automation. Targeted at unmodded Android phones running
+GameGuardian / Cheat Engine and rooted-device farms running Frida.
+
+## Threat model
+
+| Asset | Adversary | Capability |
+|:------|:----------|:-----------|
+| HP / damage / cooldown timers | Casual cheaters with GameGuardian | Memory scan → freeze value at "max" |
+| Currency / loot rolls | Account-selling farms | Modify in-process or replay-attack server endpoints |
+| Anti-cheat detection logic | Reverse engineers writing bypass scripts | Decompile + write a Frida script that hooks the check |
+| Server-auth tokens | Botting frameworks | Hook the request signer to mint fake actions |
+
+## Policy file
+
+```json title="kagura-game.json"
+{
+  "profile": "BALANCED",
+  "passes": {
+    "str":     true,
+    "wstr":    true,
+    "mvo":     true,
+    "pe":      true,
+    "fla":     true,
+    "bcf":     true,
+    "sub":     true,
+    "anti-debug": true,
+    "tamper":  true,
+    "bbcheck": false,
+    "honey":   true,
+    "telemetry": true
+  },
+  "tuning": {
+    "bcf_prob": 40,
+    "seed":     0
+  }
+}
+```
+
+Why these choices:
+
+- **BALANCED-equivalent** — games are FPS-sensitive. STRONG profile costs
+  too much frame budget; reserve `kagura_vm` for non-hot functions like the
+  daily-reward signer
+- **`bbcheck: false`** — per-BB checksums add 2–5% to **every** function;
+  not worth it for a 60fps render loop
+- **`telemetry`** — emit detection events to your server so a population of
+  cheaters becomes visible even if a single client crashes / responds
+  softly
+
+## Source-side: `Protected<T>` for game state
+
+```cpp
+#include "kagura/game_protect.h"
+
+class Player {
+    kagura::Protected<int>   hp_      {100};
+    kagura::Protected<int>   gold_    {0};
+    kagura::Protected<float> speed_   {5.5f};
+    kagura::Protected<int>   ammo_    {30};
+
+public:
+    void takeDamage(int dmg) {
+        hp_ -= dmg;
+        if (hp_ <= 0) die();
+    }
+    void rewardKill(int g) { gold_ += g; }
+};
+
+// One-time setup in main()
+void initAntiCheat() {
+    kagura::Protected<int>::setTamperCallback([] {
+        // Soft response: don't crash — report to server, then desync the
+        // player's session so future actions are rejected anyway.
+        kagura_telemetry_report("tamper_detected", 1);
+        // Optionally roll dice on a delayed crash to avoid giving an
+        // attacker a clean detection point.
+    });
+}
+```
+
+Why `Protected<T>` over raw `kagura-mvo`:
+
+| Feature | `kagura-mvo` (compile-time) | `Protected<T>` (runtime) |
+|:--------|:----------------------------|:-------------------------|
+| Encrypts on stack | ✅ at every store/load | ✅ |
+| Detects external write | ❌ | ✅ shadow-copy mismatch |
+| Per-instance key | ❌ (one PRNG seed/build) | ✅ ASLR + stack entropy |
+| Crosses ABI boundaries | ❌ | ✅ |
+
+Use **both** — `kagura-mvo` covers everything you forgot to wrap in
+`Protected<T>`.
+
+## Build
+
+```bash
+# Unity IL2CPP example — see docs/integration/unity.md for the post-build hook
+clang -fpass-plugin=KaguraObfuscator.dylib \
+      -mllvm -kagura-config=kagura-game.json \
+      -mllvm -kagura-build-id=$(date +%Y%m%d-$BUILD_NUMBER) \
+      -O2 your_il2cpp_sources.cpp -o libil2cpp.so
+```
+
+The `-kagura-build-id` ensures every release uses a different XOR mask, so a
+cheat trainer built for v1.0.4 doesn't work on v1.0.5.
+
+## Runtime checks
+
+In your title-screen / first-frame code:
+
+```cpp
+void onFirstFrame() {
+    // Probe for hook frameworks (Frida gadget, Substrate, fishhook, etc.)
+    if (kagura_check_loaded_libraries() != 0) {
+        // Don't kick the player — just disable competitive features
+        disableLeaderboards();
+        kagura_telemetry_report("hooked_libs", 1);
+    }
+
+    // Probe for debugger attach
+    if (kagura_check_breakpoints() != 0 || kagura_check_emulator() != 0) {
+        // Same: feature-gate, don't crash
+        disableLeaderboards();
+        kagura_telemetry_report("debugger_or_emu", 1);
+    }
+}
+```
+
+## Verification
+
+```bash
+# 1. GameGuardian-style value scan should find nothing
+#    Use a debug build with Protected<int> hp(100) and run a memory scanner
+#    looking for the value 100 — should not appear in a memory snapshot
+
+# 2. Frida resistance probes
+cd tests/frida_resistance
+for s in probes/F*.js; do
+    timeout 10 frida -l "$s" -f com.yourgame.app
+done
+
+# 3. Confirm telemetry events fire on a rooted emulator
+adb -e shell setprop frida.gadget.injected 1
+# launch game → expect kagura_telemetry "hooked_libs" event in your SOC
+```
+
+## What's still on you
+
+- **Server-side authority over economy.** Any item drop / currency
+  reward / leaderboard rank must be **server-authoritative**. Kagura makes
+  the client harder to tamper with; it does not stop a determined attacker
+  from manipulating client state. Treat the client as untrusted.
+- **Replay protection on server API.** A signed request that an attacker
+  intercepts can still be replayed. Use server-side nonces + timestamps.
+- **Banning policy.** Telemetry without ban automation is just dashboards.
+  Have a process for acting on `tamper_detected` events.

--- a/docs/cookbook/sdk-vendor.md
+++ b/docs/cookbook/sdk-vendor.md
@@ -1,0 +1,174 @@
+# SDK / library vendor
+
+Ship a `.a` / `.so` / `.dylib` that protects your proprietary algorithms from
+extraction, **without requiring SDK consumers to change how they build their
+app**. The integration must be transparent — your customer should still be
+able to type `npm install` / `pod install` / `gradle build` and get a working
+binary.
+
+## Threat model
+
+| Asset | Adversary | Capability |
+|:------|:----------|:-----------|
+| Proprietary algorithm (e.g. ML model weights, ranking logic, codec) | Competitor SDK vendors | Decompile your `.a` to extract the algorithm and re-implement |
+| API authentication scheme | SDK consumers themselves | Strip your call-home, repackage as their own |
+| License-key validation | End users of your customers' apps | Patch out the "is_licensed" check |
+| Backdoor / debug paths | Security researchers | Find and publicly disclose internal debug entry points |
+
+## Policy file
+
+The SDK case is different from app cases: **you cannot crash on detection**
+because your customer's app will crash. Soft responses only.
+
+```json title="kagura-sdk-release.json"
+{
+  "profile": "STRONG",
+  "passes": {
+    "str-aes":  true,
+    "wstr":     true,
+    "co":       true,
+    "fla":      true,
+    "bcf":      true,
+    "sub":      true,
+    "mvo":      true,
+    "pe":       true,
+    "genc":     true,
+    "sv":       true,
+    "honey":    true,
+    "ci":       true,
+    "vtp":      true,
+    "anti-debug": false,
+    "tamper":   false,
+    "bbcheck":  false
+  },
+  "tuning": {
+    "bcf_prob": 60,
+    "seed":     0
+  }
+}
+```
+
+Disabled passes — and why:
+
+- **`anti-debug` / `tamper`** — these can break legitimate consumer debugging
+  workflows (Xcode debugger, Android Studio, crash reporters). Move those
+  checks into a **user-opt-in** runtime API instead (see below).
+- **`bbcheck`** — same reasoning; introduces aborts that your consumer can't
+  predict.
+
+## Build
+
+```bash
+# Compile your SDK with obfuscation; consumers link the result normally
+clang -fpass-plugin=KaguraObfuscator.dylib \
+      -mllvm -kagura-config=kagura-sdk-release.json \
+      -mllvm -kagura-sv \
+      -mllvm -kagura-symmap \
+      -mllvm -kagura-symmap-out=sdk-internal-symmap.json \
+      -O2 -c sdk_core.c -o sdk_core.o
+
+ar rcs libYourSDK.a sdk_core.o ...
+# Or for shared library:
+clang -shared -fpass-plugin=… -O2 sdk_core.c -o libYourSDK.dylib
+```
+
+Store `sdk-internal-symmap.json` **internally** — never ship it. Use it to
+symbolicate customer-reported crash logs without giving the customer your
+internal names.
+
+## Symbol hygiene
+
+`kagura-sv` hides everything that doesn't have explicit external linkage. Use
+the export list pattern to make the public API tiny and explicit:
+
+```c
+// sdk_core.h — your public API
+#if defined(_WIN32)
+#  define YSDK_EXPORT __declspec(dllexport)
+#else
+#  define YSDK_EXPORT __attribute__((visibility("default")))
+#endif
+
+YSDK_EXPORT int  YSDK_Init(const char *license_key);
+YSDK_EXPORT int  YSDK_Process(const uint8_t *in, size_t n, uint8_t **out);
+YSDK_EXPORT void YSDK_Free(uint8_t *p);
+```
+
+Everything else (your ML weights, your ranking model, your codec internals)
+is hidden.
+
+## Soft anti-tamper API
+
+Expose an **opt-in** integrity API so security-conscious consumers can choose
+to enable it from their app:
+
+```c
+// public header
+YSDK_EXPORT int YSDK_SelfCheck(void);   // returns 0 if intact, non-zero if tampered
+```
+
+```c
+// in your SDK
+int YSDK_SelfCheck(void) {
+    if (kagura_self_check() != 0) return 1;
+    if (kagura_check_loaded_libraries() != 0) return 2;
+    if (kagura_check_breakpoints() != 0) return 3;
+    return 0;
+}
+```
+
+The consumer's app decides what to do with the result (refuse to issue
+licensed operations, send telemetry, etc.) — your SDK does **not** crash.
+
+## Per-customer variants
+
+Use `scripts/variant_generator.py` to produce a different XOR key set per
+customer. If customer A's binary leaks, attackers can't reuse the key
+extraction against customer B:
+
+```bash
+python3 scripts/variant_generator.py \
+    --config kagura-sdk-release.json \
+    --customer-id ACME-CORP \
+    --out kagura-acme.json
+
+clang -fpass-plugin=KaguraObfuscator.dylib \
+      -mllvm -kagura-config=kagura-acme.json \
+      -O2 -c sdk_core.c -o sdk_core_acme.o
+```
+
+## Verification
+
+```bash
+# 1. Public API is the entire export set
+nm -gU libYourSDK.dylib | grep ' T '
+# Should show exactly the YSDK_* symbols, nothing else
+
+# 2. No internal class names leak
+strings libYourSDK.dylib | grep -E "MyRankingModel|InternalCodec|DebugMode"
+# Should be empty
+
+# 3. C++ RTTI is obfuscated (kagura-vtp)
+strings libYourSDK.dylib | grep "_ZTS"
+# Type names should be unreadable
+
+# 4. Linkable from a clean consumer project
+mkdir consumer-test && cd consumer-test
+cat > main.c << 'EOF'
+#include "sdk_core.h"
+int main(void) { return YSDK_Init("test"); }
+EOF
+clang main.c ../libYourSDK.dylib -o test
+./test
+```
+
+## What's still on you
+
+- **Don't ship a free trial mode in the same binary** as the paid build.
+  Per-tier feature flags compiled into one binary are trivial to flip with
+  `kagura-honey`-defeating decompilers. Build separate binaries.
+- **License validation that can't be patched** is impossible client-side —
+  use a **server callback** that fails gracefully offline, not a pure
+  client-side bit flip.
+- **Customer can still wrap your SDK in another SDK and steal credit.**
+  That's a legal / contractual problem; technical measures are limited.

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,14 @@ Kagura addresses this at the IR level — before the compiler turns IR into mach
 
     Xcode, Gradle/NDK, Unity, Unreal, CMake, Bazel, CocoaPods, SPM.
 
+- :material-book-open-variant: **[Cookbook](cookbook/index.md)**
+
+    Banking, mobile game, SDK vendor, DRM — recipe-style guides with policy + verification.
+
+- :material-shield-search: **[Security Model](security-model.md)**
+
+    What Kagura protects, what it doesn't, and assumptions you can't violate.
+
 - :material-cog: **[Configuration](configuration.md)**
 
     JSON policy DSL, strength profiles, CLI tuning parameters, deterministic pass order.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1,0 +1,165 @@
+# Security Model
+
+Kagura is one layer of a defense-in-depth strategy. This page is explicit about
+**what it protects, what it does not, and what assumptions break it**, so you
+can decide where Kagura fits in your threat model and where you still need
+other controls.
+
+---
+
+## What Kagura is for
+
+Kagura raises the cost of reverse engineering native code that ships to
+adversarial environments — anti-cheat in games, key material in banking /
+DRM apps, proprietary algorithms in SDKs. It does this entirely at the
+**LLVM IR level**, before any architecture-specific code generation, so every
+protection applies across iOS, Android, macOS, Windows, Linux, and WebAssembly
+from a single build step.
+
+## Threat model
+
+The model below uses [STRIDE](https://en.wikipedia.org/wiki/STRIDE_model)
+categories, but only the ones Kagura actually addresses. Tampering and
+Information Disclosure are the primary categories; the others are out of scope
+or partially covered.
+
+| Category | Adversary capability | Kagura coverage |
+|:---------|:---------------------|:----------------|
+| **Information Disclosure** | Static binary analysis (strings, IDA, Ghidra, Binary Ninja) | ✅ Strong — string encryption, CFG flattening, MBA, symbol hiding, RTTI obfuscation, DWARF strip |
+| **Information Disclosure** | Live memory inspection (Cheat Engine, GameGuardian, /proc/maps) | ✅ Strong — MVO/PE encrypt values at every store, `Protected<T>` adds shadow-copy detection |
+| **Tampering** | Binary patching (NOP-ing checks, replacing instructions) | ✅ Medium — per-BB opcode checksums (`kagura-bbcheck`) abort on modification |
+| **Tampering** | Loader hooking (Frida, Substrate, fishhook) | ✅ Medium — runtime detection probes for hook frameworks, suspicious dylib / .so scan |
+| **Tampering** | Debugger attach (ptrace, lldb, WinDbg) | ✅ Medium — `kagura-anti-debug` covers ptrace, IsDebuggerPresent, PEB heap flags, Frida ports |
+| **Information Disclosure** | Symbolic / concolic execution (angr, KLEE, S2E) | ⚠️ Partial — `kagura-fla` + `kagura-bcf` + `kagura-co` raise path explosion; see `tests/symbolic_exec/` for measurements |
+| **Information Disclosure** | LLM-assisted decompilation | ⚠️ Partial — name stripping helps; MBA hurts readability but is not a hard barrier |
+| **Repudiation** | Crash attribution / forensic logging | 🟡 Out of scope — use platform crash reporters, optionally enable `-kagura-symmap` for offline symbolication |
+| **Denial of Service** | Targeted crashes | 🟡 Out of scope |
+| **Elevation of Privilege** | Sandbox escape, kernel exploitation | 🟡 Out of scope |
+
+✅ Strong = direct, well-tested coverage.
+⚠️ Partial = raises cost; not a hard guarantee.
+🟡 Out of scope = use other tooling.
+
+---
+
+## What Kagura does **not** protect
+
+Be explicit about the boundaries — these are real and need other controls.
+
+### Plaintext server-side secrets
+Anything decrypted at runtime is plaintext **in registers and memory** for the
+duration of its use. Kagura minimizes the window (`kagura-str`'s decrypt-zero
+loop) but cannot eliminate it. **Sensitive secrets that must survive a memory
+dump belong server-side**, not in the client binary.
+
+### Cryptographic primitives
+Kagura encrypts string literals and values for **obscurity**, not
+confidentiality against a determined adversary with debugger access. The AES
+key used by `kagura-str-aes` is derived from build metadata; an attacker who
+extracts the key once can decrypt all subsequent strings in the same build.
+Use `-kagura-build-id=<sha>` to rotate keys per release, but recognize this
+defeats *batch* extraction, not *single-binary* extraction.
+
+### Side channels
+Cache timing, EM emanation, power analysis, speculative execution, and
+hardware-level attacks are **not** in scope. If you're shipping crypto on a
+device adversaries physically control, use a hardware-backed keystore (SE,
+StrongBox, Secure Enclave).
+
+### Determined adversaries with unlimited time
+Kagura raises the cost in **analyst-hours**. A well-resourced adversary will
+eventually deobfuscate everything. The goal is to move the bar above your
+target attacker's economic threshold — measured for your use case via
+`scripts/attacker_cost_model.py` and the angr / Ghidra / Frida resistance
+suites under `tests/`.
+
+### Side-effects from the operating system
+- iOS Keychain reads / Android Keystore calls bypass IR-level protections —
+  use the platform key store for keys that must persist.
+- TrustZone / SGX / SEV protections are higher-assurance and orthogonal.
+- The OS loader still sees your imports — `kagura-ci` helps, but cannot hide
+  all `dlopen` / `LoadLibrary` calls.
+
+---
+
+## Assumptions Kagura relies on
+
+These are the assumptions that, when violated, weaken Kagura's protections.
+
+### 1. The plugin is loaded for every translation unit
+If a single source file in the build is compiled without `-fpass-plugin=…`,
+its strings and CFG are plaintext. Build-system integration matters — see
+[Integration](integration/index.md) and audit the build with
+`scripts/kagura-cli.py audit-log` or `-kagura-audit`.
+
+### 2. The pass order is preserved
+`kagura-tamper` measures function checksums **before** CFG-mutating passes
+run. If a third-party LLVM pass inserts itself between them, the checksums
+become wrong. See [Pass Order](pass-order.md). Run `verify-reproducible.sh`
+to confirm a fixed seed still produces identical IR.
+
+### 3. The runtime library is linked
+`kagura-str-aes`, `kagura-anti-debug`, `kagura-tamper`, `kagura-pac`,
+`kagura-vm`, `kagura-bbcheck` all need symbols in `libkagura_runtime.a`. A
+missing link results in undefined symbols at load time — surfaces the problem
+early, but also means missing the runtime means missing the protection.
+
+### 4. Reproducibility is honored
+Setting `-kagura-seed=0` (entropy default) produces a different binary each
+build. Forensically that's good (per-binary watermarking is implicit), but it
+also means **per-build variant generation is on you** — use
+`scripts/variant_generator.py` if you ship per-customer variants.
+
+### 5. Anti-tamper response is sensible
+`kagura-tamper`'s default response is `abort()`, which gives a clean crash
+attribution point. For shipping apps, replace with `setTamperCallback()` (see
+[Game Protection](game-protection.md)) to do soft response — random delays,
+poisoned data, or telemetry — making the detection point itself harder to
+locate via differential debugging.
+
+---
+
+## How to evaluate coverage
+
+Kagura ships measurement tools that let you quantify protection on your
+binary, not just trust marketing claims.
+
+| Tool | Question it answers |
+|:-----|:--------------------|
+| `scripts/attacker_cost_model.py`  | "How many analyst-hours does this configuration cost an attacker?" |
+| `tests/symbolic_exec/run_angr_eval.py` | "Does my binary survive 30-minute angr concolic execution?" |
+| `tests/decompiler_eval/run_ghidra_eval.py` | "Does Ghidra reconstruct readable C from my binary?" |
+| `tests/frida_resistance/` | "Are my hook / breakpoint / debugger probes catching the F1–F8 Frida vectors?" |
+| `scripts/review-risk-assessment.sh` | "Will the App Store / Play Store reject my binary for the protections I added?" |
+| `scripts/kagura-diff.py` | "Did my release build actually hide the symbols and encrypt the strings it was supposed to?" |
+
+Run these on **your own representative builds**. The numbers in
+[Performance & Size Impact](passes/performance.md) are illustrative; the only
+numbers that matter for your project are the ones you measure on your code.
+
+---
+
+## Recommended layering
+
+Kagura should be **one layer** in your stack. A realistic mobile / banking /
+DRM deployment looks roughly like:
+
+1. **Server-side authority** — anything that must not be tampered with
+   (entitlements, currency totals, license validity) is authoritative on the
+   server, not the client.
+2. **Platform key stores** — Apple Keychain / Secure Enclave, Android
+   Keystore / StrongBox for keys that must persist across runs.
+3. **Platform attestation** — Apple DeviceCheck / App Attest, Android Play
+   Integrity for "this device looks legit". (See
+   [Integration](integration/index.md) for build-system wiring; SDK adapters
+   live under `runtime/ios/` and `runtime/android/`.)
+4. **Kagura compile-time obfuscation + runtime checks** — the layer this
+   project covers.
+5. **Application-level checks** — rate limits, anomaly detection, server-side
+   replay protection.
+6. **Operational telemetry** — `kagura-telemetry` events flowing to your SOC
+   so you can react to detection signals at population scale.
+
+Removing any one layer weakens the whole stack. Kagura by itself is not a
+security product; it's a **building block** that makes the other layers
+harder to attack.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,13 @@ nav:
       - Bazel: integration/bazel.md
       - CocoaPods: integration/cocoapods.md
       - Swift Package Manager: integration/swiftpm.md
+  - Cookbook:
+      - cookbook/index.md
+      - Banking / FinTech: cookbook/banking.md
+      - Mobile game / anti-cheat: cookbook/mobile-game.md
+      - SDK / library vendor: cookbook/sdk-vendor.md
+      - DRM / license enforcement: cookbook/drm.md
+  - Security Model: security-model.md
   - Configuration:
       - Overview: configuration.md
       - Tuning Parameters: tuning.md


### PR DESCRIPTION
## Summary

Adds two doc surfaces requested in the planning thread:

### Security Model
**`docs/security-model.md`** — explicit about what Kagura protects and what it doesn't. Sections:

- STRIDE coverage matrix with realistic strength ratings (✅ strong / ⚠️ partial / 🟡 out of scope)
- Hard non-goals: plaintext server-side secrets, cryptographic primitives, side channels, determined adversaries with unlimited time, OS-level surfaces
- Five load-bearing assumptions Kagura relies on (plugin loaded everywhere, pass order preserved, runtime linked, reproducibility honored, sensible anti-tamper response)
- Self-evaluation tool matrix (each measurement script paired with the threat it answers)
- Recommended defense-in-depth layering

### Cookbook
**`docs/cookbook/{banking, mobile-game, sdk-vendor, drm}.md`** — recipe pages, each containing:

1. Scenario-specific threat model
2. Complete `kagura.json` policy with rationale
3. Build commands (including `-kagura-build-id` for per-release key rotation)
4. Source-side annotations and runtime hardening code
5. Verification commands (strings / Ghidra / Frida / kagura-diff / review-risk)
6. Explicit "still on you" callouts so the boundary stays visible

### Wiring
- Sidebar nav: Cookbook section + standalone Security Model page
- Homepage card grid: two new entries

## Test plan

- [x] `mkdocs build --strict` passes
- [ ] Visual review of Cookbook recipes for any policy choices that contradict the [Performance & Size Impact](https://ykus4.github.io/kagura/passes/performance/) page

## Branching note

Authored from `main` (PR #39 not yet merged). No conflicts expected — disjoint file set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)