### PR TITLE
fix(kagura-opt): make -kagura-* flags work + pass instrumentation

### DIFF
--- a/tests/lit/string-encryption-aes.ll
+++ b/tests/lit/string-encryption-aes.ll
@@ -3,12 +3,12 @@
 ; StringEncryptionAESPass encrypts string literals with AES-128-CTR.
 ; After the pass:
 ;   - The plaintext string content must not appear.
-;   - An AES-encrypted blob global (kagura_aes_enc_) must be emitted.
-;   - A runtime decryption call (kagura_aes_decrypt_str) must be injected.
+;   - An AES-encrypted blob global (kagura_aesenc_) must be emitted.
+;   - A per-string runtime decryption stub (kagura_aesdec_) must be injected.
 
 ; CHECK-NOT: c"supersecret\00"
-; CHECK: @kagura_aes_enc_
-; CHECK: kagura_aes_decrypt_str
+; CHECK: @kagura_aesenc_
+; CHECK: kagura_aesdec_
 
 @secret = private unnamed_addr constant [12 x i8] c"supersecret\00"
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -12,14 +12,25 @@ add_llvm_executable(kagura-opt
   kagura-opt.cpp
 )
 
-llvm_map_components_to_libnames(KAGURA_OPT_LLVM_LIBS
-  Core
-  Support
-  IRReader
-  BitWriter
-  BitReader
-  Passes
-)
+# Link LLVM exactly once.  When LLVM is built with LLVM_LINK_LLVM_DYLIB=ON
+# (e.g. Homebrew), add_llvm_executable already links libLLVM.dylib; also adding
+# the static component archives (libLLVMSupport.a, ...) links a *second* copy of
+# the cl::opt command-line registry into this binary.  The kagura plugin, loaded
+# at runtime, registers its -kagura-* options into the dylib's registry, so with
+# a duplicate static registry cl::ParseCommandLineOptions() here would never see
+# them.  Link the shared libLLVM in dylib mode, static components otherwise.
+if(LLVM_LINK_LLVM_DYLIB)
+  set(KAGURA_OPT_LLVM_LIBS LLVM)
+else()
+  llvm_map_components_to_libnames(KAGURA_OPT_LLVM_LIBS
+    Core
+    Support
+    IRReader
+    BitWriter
+    BitReader
+    Passes
+  )
+endif()
 
 target_link_libraries(kagura-opt PRIVATE
   ${KAGURA_OPT_LLVM_LIBS}

--- a/tools/kagura-opt.cpp
+++ b/tools/kagura-opt.cpp
@@ -36,9 +36,11 @@
 #include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IR/PassInstrumentation.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/StandardInstrumentations.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/InitLLVM.h"
@@ -81,33 +83,55 @@ static cl::opt<std::string> PluginPath(
 
 // ---- Plugin path auto-detection ---------------------------------------------
 
-static std::string findPlugin(const char *Argv0) {
-  if (!PluginPath.empty())
-    return PluginPath;
+static std::string getExplicitPluginPath(int argc, char **argv) {
+  StringRef Prefix("-load-kagura=");
+  for (int I = 1; I < argc; ++I) {
+    StringRef Arg(argv[I]);
+    if (Arg.starts_with(Prefix))
+      return Arg.drop_front(Prefix.size()).str();
+    if (Arg == "-load-kagura" && I + 1 < argc)
+      return std::string(argv[I + 1]);
+  }
+  return "";
+}
 
-  // Try <exe_dir>/../lib/libKaguraObfuscator.{dylib,so}
-  SmallString<256> ExeDir(sys::path::parent_path(
-      sys::fs::getMainExecutable(Argv0, nullptr)));
-  sys::path::append(ExeDir, "..", "lib");
-
-  for (const char *Ext : {"libKaguraObfuscator.dylib",
-                           "libKaguraObfuscator.so",
-                           "KaguraObfuscator.dll"}) {
-    SmallString<256> Candidate(ExeDir);
-    sys::path::append(Candidate, Ext);
+// Return the first existing "<Dir>/<name>" for every known plugin filename,
+// or "" if none of them exist in Dir.
+static std::string findPluginInDir(StringRef Dir) {
+  static const char *const Names[] = {
+      "KaguraObfuscator.dylib", "libKaguraObfuscator.dylib",
+      "KaguraObfuscator.so",    "libKaguraObfuscator.so",
+      "KaguraObfuscator.dll",
+  };
+  for (const char *Name : Names) {
+    SmallString<256> Candidate(Dir);
+    sys::path::append(Candidate, Name);
     if (sys::fs::exists(Candidate))
       return std::string(Candidate);
   }
+  return "";
+}
 
-  // Fallback: look next to the executable
-  SmallString<256> ExePath(sys::path::parent_path(
+static std::string findPlugin(const char *Argv0, StringRef ExplicitPath) {
+  if (!ExplicitPath.empty())
+    return ExplicitPath.str();
+
+  SmallString<256> ExeDir(sys::path::parent_path(
       sys::fs::getMainExecutable(Argv0, nullptr)));
-  for (const char *Ext : {"libKaguraObfuscator.dylib",
-                           "libKaguraObfuscator.so"}) {
-    SmallString<256> Candidate(ExePath);
-    sys::path::append(Candidate, Ext);
-    if (sys::fs::exists(Candidate))
-      return std::string(Candidate);
+
+  // Search, in priority order: <exe_dir>/../lib, <exe_dir>/../lib/Transforms
+  // (where CMake's add_llvm_pass_plugin drops the plugin in normal build
+  // trees), and finally next to the executable itself.
+  SmallString<256> LibDir(ExeDir);
+  sys::path::append(LibDir, "..", "lib");
+
+  SmallString<256> TransformDir(LibDir);
+  sys::path::append(TransformDir, "Transforms");
+
+  for (StringRef Dir : {StringRef(LibDir), StringRef(TransformDir),
+                        StringRef(ExeDir)}) {
+    if (std::string Found = findPluginInDir(Dir); !Found.empty())
+      return Found;
   }
   return "";
 }
@@ -116,11 +140,11 @@ static std::string findPlugin(const char *Argv0) {
 
 int main(int argc, char **argv) {
   InitLLVM X(argc, argv);
-  cl::ParseCommandLineOptions(argc, argv,
-                               "kagura-opt -- apply kagura obfuscation passes\n");
 
-  // Load the kagura plugin (registers all -kagura-* passes and cl::opts)
-  std::string Plugin = findPlugin(argv[0]);
+  // Load the kagura plugin before parsing command-line options.  The plugin
+  // owns the -kagura-* cl::opts, so parsing first would reject those flags as
+  // unknown.
+  std::string Plugin = findPlugin(argv[0], getExplicitPluginPath(argc, argv));
   if (Plugin.empty()) {
     WithColor::error() << "Could not find libKaguraObfuscator plugin.\n"
                        << "Use -load-kagura=<path> to specify it explicitly.\n";
@@ -133,6 +157,9 @@ int main(int argc, char **argv) {
                        << toString(PluginOrErr.takeError()) << '\n';
     return 1;
   }
+
+  cl::ParseCommandLineOptions(argc, argv,
+                               "kagura-opt -- apply kagura obfuscation passes\n");
 
   // Load the input module
   LLVMContext Ctx;
@@ -155,14 +182,23 @@ int main(int argc, char **argv) {
   default:  OL = OptimizationLevel::O2; break;
   }
 
-  // Construct the pass pipeline with the kagura plugin registered.
-  PassBuilder PB;
-  PluginOrErr->registerPassBuilderCallbacks(PB);
-
   LoopAnalysisManager     LAM;
   FunctionAnalysisManager FAM;
   CGSCCAnalysisManager    CGAM;
   ModuleAnalysisManager   MAM;
+
+  PassInstrumentationCallbacks PIC;
+  StandardInstrumentations SI(Ctx, /*DebugLogging=*/false);
+  SI.registerCallbacks(PIC, &MAM);
+  LAM.registerPass([&] { return PassInstrumentationAnalysis(&PIC); });
+  FAM.registerPass([&] { return PassInstrumentationAnalysis(&PIC); });
+  CGAM.registerPass([&] { return PassInstrumentationAnalysis(&PIC); });
+  MAM.registerPass([&] { return PassInstrumentationAnalysis(&PIC); });
+
+  // Construct the pass pipeline with the kagura plugin registered.
+  PassBuilder PB(nullptr, PipelineTuningOptions(), std::nullopt, &PIC);
+  PluginOrErr->registerPassBuilderCallbacks(PB);
+
   PB.registerModuleAnalyses(MAM);
   PB.registerCGSCCAnalyses(CGAM);
   PB.registerFunctionAnalyses(FAM);


### PR DESCRIPTION
## Background
`kagura-opt` could never accept the plugin's `-kagura-*` flags. The root cause is a **duplicated `cl::opt` command-line registry**.

When `LLVM_LINK_LLVM_DYLIB=ON` (e.g. Homebrew), `add_llvm_executable` links `libLLVM.dylib` automatically, while `llvm_map_components_to_libnames` *also* linked the static `libLLVMCore.a` / `libLLVMSupport.a` / … archives. That left two copies of the CommandLine registry in the binary. The plugin, loaded at runtime via `PassPlugin::Load()`, registers its `-kagura-*` options into the **dylib's** registry, but the tool's `cl::ParseCommandLineOptions()` reads the **static** one — so every `-kagura-*` flag was rejected as unknown.

## Changes
- **`tools/CMakeLists.txt`**: link the shared `LLVM` in dylib mode, static components otherwise, so there is exactly one command-line registry.
- **`tools/kagura-opt.cpp`**:
  - load the plugin **before** parsing options
  - register `StandardInstrumentations` so `-time-passes` / `-print-after-all` work
  - collapse the three duplicated plugin-filename search arrays into `findPluginInDir()`
- **`tests/lit/string-encryption-aes.ll`**: update stale CHECK symbol names to the actual output (`kagura_aesenc_` / `kagura_aesdec_`).

## Verification
- `kagura-opt -kagura-str in.ll -S` now actually encrypts strings (plaintext gone, decrypt stub injected).
- `-time-passes` emits pass timing.
- Full `ctest` suite: **41/41 passed**.