### PR TITLE
refactor: extract createCtorFunction() helper for module constructors

### DIFF
--- a/include/kagura/Utils.h
+++ b/include/kagura/Utils.h
@@ -58,6 +58,14 @@ std::vector<llvm::BasicBlock *> getBlocks(llvm::Function &F);
 llvm::Function *getOrDeclare(llvm::Module &M, llvm::StringRef Name,
                              llvm::FunctionType *FTy);
 
+/// Create an InternalLinkage `void()` function named `Name` in `M` with a
+/// single empty "entry" basic block — the shape every kagura module
+/// constructor shares. The caller adds any function attributes, emits the body
+/// and its terminator, and (for module ctors) registers it via
+/// llvm::appendToGlobalCtors(). Retrieve the entry block with
+/// `&F->getEntryBlock()`.
+llvm::Function *createCtorFunction(llvm::Module &M, const llvm::Twine &Name);
+
 // ---- Exception-handling safety ----
 
 /// Returns true if F contains any invoke or landingpad instructions.

--- a/lib/Transforms/AntiAnalysis/CallIndirection.cpp
+++ b/lib/Transforms/AntiAnalysis/CallIndirection.cpp
@@ -148,13 +148,11 @@ static Function *buildInitConstructor(Module &M, GlobalVariable *ThunkTable,
   auto *Int64Ty = Type::getInt64Ty(Ctx);
 
   // void kagura_init_thunk_table(void)
-  auto *FTy  = FunctionType::get(Type::getVoidTy(Ctx), false);
-  auto *Ctor = Function::Create(FTy, Function::InternalLinkage,
-                                "kagura_init_thunk_table", M);
+  auto *Ctor = createCtorFunction(M, "kagura_init_thunk_table");
   Ctor->addFnAttr(Attribute::NoInline);
   Ctor->addFnAttr(Attribute::NoUnwind);
 
-  auto *Entry = BasicBlock::Create(Ctx, "entry", Ctor);
+  auto *Entry = &Ctor->getEntryBlock();
   IRBuilder<> B(Entry);
 
   Function *DlsymFn        = getOrDeclareDlsym(M);

--- a/lib/Transforms/AntiAnalysis/HoneyValue.cpp
+++ b/lib/Transforms/AntiAnalysis/HoneyValue.cpp
@@ -154,18 +154,15 @@ static void buildHoneyAnchorCtor(
     const SmallVectorImpl<GlobalVariable *> &HoneyGVs,
     const SmallVectorImpl<Function *> &FakeFns) {
   LLVMContext &Ctx = M.getContext();
-  auto *VoidTy     = Type::getVoidTy(Ctx);
   auto *Int32Ty    = Type::getInt32Ty(Ctx);
   auto *Int8Ty     = Type::getInt8Ty(Ctx);
   auto *PtrTy      = PointerType::getUnqual(Ctx);
 
-  auto *FTy = FunctionType::get(VoidTy, false);
-  auto *Ctor = Function::Create(FTy, Function::InternalLinkage,
-                                "kagura_honey_ctor", M);
+  auto *Ctor = createCtorFunction(M, "kagura_honey_ctor");
   Ctor->addFnAttr(Attribute::NoInline);
   Ctor->addFnAttr(Attribute::NoUnwind);
 
-  auto *Entry = BasicBlock::Create(Ctx, "entry", Ctor);
+  auto *Entry = &Ctor->getEntryBlock();
   IRBuilder<> B(Entry);
 
   // Volatile load from each honey global to prevent elimination.

--- a/lib/Transforms/AntiAnalysis/PointerAuth.cpp
+++ b/lib/Transforms/AntiAnalysis/PointerAuth.cpp
@@ -135,13 +135,11 @@ static Function *buildPacKeyConstructor(Module &M, GlobalVariable *PacKey) {
       M.getOrInsertFunction("kagura_random_u64", RngFTy).getCallee());
 
   // void kagura_init_pac_key(void)
-  auto *CtorFTy = FunctionType::get(Type::getVoidTy(Ctx), false);
-  auto *Ctor    = Function::Create(CtorFTy, Function::InternalLinkage,
-                                   "kagura_init_pac_key", M);
+  auto *Ctor = createCtorFunction(M, "kagura_init_pac_key");
   Ctor->addFnAttr(Attribute::NoInline);
   Ctor->addFnAttr(Attribute::NoUnwind);
 
-  auto *Entry = BasicBlock::Create(Ctx, "entry", Ctor);
+  auto *Entry = &Ctor->getEntryBlock();
   IRBuilder<> B(Entry);
 
   // kagura_pac_key = kagura_random_u64()
@@ -326,13 +324,11 @@ static GlobalVariable *hwPACTagGlobal(GlobalVariable *GV, Module &M,
   Tagged->setSection(GV->getSection());
 
   // Build a constructor that signs the pointer and stores it.
-  auto *CtorFTy = FunctionType::get(Type::getVoidTy(Ctx), false);
-  auto *Ctor = Function::Create(CtorFTy, Function::InternalLinkage,
-                                GV->getName() + ".hwpac.init", M);
+  auto *Ctor = createCtorFunction(M, GV->getName() + ".hwpac.init");
   Ctor->addFnAttr(Attribute::NoInline);
   Ctor->addFnAttr(Attribute::NoUnwind);
 
-  auto *Entry = BasicBlock::Create(Ctx, "entry", Ctor);
+  auto *Entry = &Ctor->getEntryBlock();
   IRBuilder<> B(Entry);
 
   Constant *OrigFn = GV->getInitializer();

--- a/lib/Transforms/CFG/VTableProtection.cpp
+++ b/lib/Transforms/CFG/VTableProtection.cpp
@@ -102,7 +102,6 @@ static bool obfuscateMSVCTypeName(GlobalVariable *GV, Module &M, PRNG &RNG) {
     LLVMContext &Ctx = M.getContext();
     auto *Int8Ty  = Type::getInt8Ty(Ctx);
     auto *Int64Ty = Type::getInt64Ty(Ctx);
-    auto *VoidTy  = Type::getVoidTy(Ctx);
     auto *PtrTy   = PointerType::getUnqual(Ctx);
 
     // Encrypt the name bytes (preserve NUL terminator)
@@ -122,13 +121,11 @@ static bool obfuscateMSVCTypeName(GlobalVariable *GV, Module &M, PRNG &RNG) {
 
     // Build a constructor to decrypt in-place
     // The name field is at a fixed offset = sizeof(ptr) * 2
-    auto *CtorFTy = FunctionType::get(VoidTy, false);
-    auto *Ctor = Function::Create(CtorFTy, Function::InternalLinkage,
-                                  GV->getName() + ".msvc_rtti_decrypt", M);
+    auto *Ctor = createCtorFunction(M, GV->getName() + ".msvc_rtti_decrypt");
     Ctor->addFnAttr(Attribute::NoInline);
     Ctor->addFnAttr(Attribute::NoUnwind);
 
-    auto *Entry = BasicBlock::Create(Ctx, "entry", Ctor);
+    auto *Entry = &Ctor->getEntryBlock();
     auto *Loop  = BasicBlock::Create(Ctx, "loop",  Ctor);
     auto *Exit  = BasicBlock::Create(Ctx, "exit",  Ctor);
 
@@ -184,18 +181,15 @@ static bool obfuscateRTTIName(GlobalVariable *GV, Module &M, PRNG &RNG) {
     GV->setConstant(false); // must be writable for in-place decryption
 
     // Build a constructor that XOR-decrypts the name in-place
-    auto *VoidTy = Type::getVoidTy(Ctx);
     auto *I8PtrTy = PointerType::getUnqual(Ctx);
     auto *I8Ty  = Type::getInt8Ty(Ctx);
     auto *I64Ty = Type::getInt64Ty(Ctx);
 
-    auto *CtorFTy = FunctionType::get(VoidTy, false);
-    auto *Ctor = Function::Create(CtorFTy, Function::InternalLinkage,
-                                  GV->getName() + ".rtti_decrypt", M);
+    auto *Ctor = createCtorFunction(M, GV->getName() + ".rtti_decrypt");
     Ctor->addFnAttr(Attribute::NoInline);
     Ctor->addFnAttr(Attribute::NoUnwind);
 
-    auto *Entry = BasicBlock::Create(Ctx, "entry", Ctor);
+    auto *Entry = &Ctor->getEntryBlock();
     auto *Loop  = BasicBlock::Create(Ctx, "loop",  Ctor);
     auto *Exit  = BasicBlock::Create(Ctx, "exit",  Ctor);
 

--- a/lib/Transforms/Data/WideStringEncryption.cpp
+++ b/lib/Transforms/Data/WideStringEncryption.cpp
@@ -271,14 +271,11 @@ static void buildCFStringDecryptCtor(
     return;
 
   LLVMContext &Ctx = M.getContext();
-  auto *VoidTy = Type::getVoidTy(Ctx);
-  auto *CtorFTy = FunctionType::get(VoidTy, false);
-  auto *Ctor    = Function::Create(CtorFTy, Function::InternalLinkage,
-                                   "kagura_cfstr_decrypt_ctor", M);
+  auto *Ctor = createCtorFunction(M, "kagura_cfstr_decrypt_ctor");
   Ctor->addFnAttr(Attribute::NoInline);
   Ctor->addFnAttr(Attribute::NoUnwind);
 
-  auto *Entry = BasicBlock::Create(Ctx, "entry", Ctor);
+  auto *Entry = &Ctor->getEntryBlock();
   IRBuilder<> B(Entry);
   for (auto &[GV, DecFn] : CFDecryptors)
     B.CreateCall(DecFn);
@@ -302,15 +299,11 @@ static void buildRuntimeStringDecryptCtor(
     int Priority) {
   if (Stubs.empty())
     return;
-  LLVMContext &Ctx = M.getContext();
-  auto *VoidTy  = Type::getVoidTy(Ctx);
-  auto *CtorFTy = FunctionType::get(VoidTy, false);
-  auto *Ctor    = Function::Create(CtorFTy, Function::InternalLinkage,
-                                   CtorName, M);
+  auto *Ctor = createCtorFunction(M, CtorName);
   Ctor->addFnAttr(Attribute::NoInline);
   Ctor->addFnAttr(Attribute::NoUnwind);
 
-  auto *Entry = BasicBlock::Create(Ctx, "entry", Ctor);
+  auto *Entry = &Ctor->getEntryBlock();
   IRBuilder<> B(Entry);
   for (auto *Stub : Stubs)
     B.CreateCall(Stub);

--- a/lib/Transforms/Platform/ObjCObfuscation.cpp
+++ b/lib/Transforms/Platform/ObjCObfuscation.cpp
@@ -187,13 +187,11 @@ PreservedAnalyses ObjCObfuscationPass::run(Module &M,
     FunctionCallee RemapFn =
         M.getOrInsertFunction("kagura_objc_register_remap", RemapFTy);
 
-    auto *CtorFTy = FunctionType::get(VoidTy, false);
-    auto *Ctor = Function::Create(CtorFTy, Function::InternalLinkage,
-                                  "kagura_objc_remap_ctor", M);
+    auto *Ctor = createCtorFunction(M, "kagura_objc_remap_ctor");
     Ctor->addFnAttr(Attribute::NoInline);
     Ctor->addFnAttr(Attribute::NoUnwind);
 
-    auto *Entry = BasicBlock::Create(Ctx, "entry", Ctor);
+    auto *Entry = &Ctor->getEntryBlock();
     IRBuilder<> B(Entry);
 
     for (auto &[Orig, Obf] : NameMap) {

--- a/lib/Transforms/Utils.cpp
+++ b/lib/Transforms/Utils.cpp
@@ -305,6 +305,14 @@ Function *getOrDeclare(Module &M, StringRef Name, FunctionType *FTy) {
   return Function::Create(FTy, Function::ExternalLinkage, Name, M);
 }
 
+Function *createCtorFunction(Module &M, const Twine &Name) {
+  LLVMContext &Ctx = M.getContext();
+  auto *FTy = FunctionType::get(Type::getVoidTy(Ctx), /*isVarArg=*/false);
+  auto *F = Function::Create(FTy, Function::InternalLinkage, Name, M);
+  BasicBlock::Create(Ctx, "entry", F);
+  return F;
+}
+
 // ---- String global collection ----
 
 std::vector<GlobalVariable *> collectStringGlobals(Module &M,


### PR DESCRIPTION
## Motivation
Nine module-constructor sites across six passes repeated the same boilerplate to create an `InternalLinkage` `void()` function with an `entry` block before emitting the body and calling `appendToGlobalCtors()`:

```cpp
auto *FTy  = FunctionType::get(Type::getVoidTy(Ctx), false);
auto *Ctor = Function::Create(FTy, Function::InternalLinkage, Name, M);
auto *Entry = BasicBlock::Create(Ctx, "entry", Ctor);
```

## Change
Extract that shape into `kagura::createCtorFunction(M, Name)` in `Utils`. Call sites become:

```cpp
auto *Ctor  = createCtorFunction(M, Name);
auto *Entry = &Ctor->getEntryBlock();
```

Converted passes:
- `CallIndirection`
- `HoneyValue`
- `PointerAuth` (software + hardware PAC ctors)
- `WideStringEncryption` (CFString + wide-string ctors)
- `VTableProtection` (MSVC + Itanium RTTI decrypt ctors)
- `ObjCObfuscation`

The helper owns **only** function/entry-block creation. Each call site keeps its own `addFnAttr()` and `appendToGlobalCtors()` with the **exact priority** it used before, so there is no behavioral change.

`AntiDebug` is intentionally left as-is: it reuses its `void()` `FunctionType` for a separate weak hook function, so the helper would not simplify it.

## Verification
- Plugin builds clean, no new warnings.
- Full `ctest` suite: **41/41 passed**.