### PR TITLE
refactor: table-drive infra-pass name parsing via KAGURA_INFRA_PASS

### DIFF
--- a/lib/Transforms/PassRegistry.def
+++ b/lib/Transforms/PassRegistry.def
@@ -32,6 +32,19 @@
 #define KAGURA_MOD_PASS(Flag, Cli, Desc, Ctor)
 #endif
 
+//   KAGURA_INFRA_PASS(CliName, Construct)
+//       Infrastructure / non-pipeline module pass. Parseable by name
+//       (opt -passes=kagura-...) but NOT auto-injected from an enable flag:
+//       each is wired into Plugin.cpp's OptimizerLast pipeline by hand because
+//       it has a bespoke trigger (a string option, "config file provided",
+//       fixed ordering relative to the obfuscation passes, etc.) that the
+//       uniform bool-flag table above cannot express. This table is the single
+//       source of truth for *which* infra pass names exist and how to build
+//       them; only the injection ordering stays hand-written.
+#ifndef KAGURA_INFRA_PASS
+#define KAGURA_INFRA_PASS(Cli, Ctor)
+#endif
+
 // ---- Module-level passes (run on the whole Module) ----
 KAGURA_MOD_PASS(CI,        "kagura-ci",            "Call indirection",                              CallIndirectionPass())
 KAGURA_MOD_PASS(PAC,       "kagura-pac",           "Pointer authentication (ARM64)",                PointerAuthPass())
@@ -66,5 +79,14 @@ KAGURA_FN_PASS(Telemetry, "kagura-telemetry",  "Inject telemetry event probes", 
 KAGURA_FN_PASS(BBCheck,   "kagura-bbcheck",    "Basic block opcode checksum guards",              BasicBlockChecksumPass())
 KAGURA_FN_PASS(ELT,       "kagura-elt",        "Encrypted lookup table (switch encoding)",        EncryptedLookupTablePass())
 
+// ---- Infrastructure passes (parseable by name, hand-injected in Plugin.cpp) ----
+KAGURA_INFRA_PASS("kagura-autoselect",    AutoSelectPass())
+KAGURA_INFRA_PASS("kagura-config",        ConfigLoaderPass())
+KAGURA_INFRA_PASS("kagura-dwarf-control", DWARFControlPass())
+KAGURA_INFRA_PASS("kagura-symmap",        SymbolMapPass())
+KAGURA_INFRA_PASS("kagura-vtp",           VTableProtectionPass())
+KAGURA_INFRA_PASS("kagura-audit",         AuditLogPass())
+
 #undef KAGURA_FN_PASS
 #undef KAGURA_MOD_PASS
+#undef KAGURA_INFRA_PASS

--- a/lib/Transforms/Plugin.cpp
+++ b/lib/Transforms/Plugin.cpp
@@ -64,33 +64,16 @@ llvm::PassPluginLibraryInfo getKaguraPluginInfo() {
                     return true;                                               \
                   }
 #include "PassRegistry.def"
-                  // Module-level passes outside the auto-pipeline table —
-                  // these have ordering or conditional quirks and are
-                  // injected explicitly in the OptimizerLast block below.
-                  if (Name == "kagura-autoselect") {
-                    MPM.addPass(AutoSelectPass());
-                    return true;
+                  // Infrastructure passes outside the auto-pipeline table —
+                  // these have ordering or conditional quirks and are injected
+                  // explicitly in the OptimizerLast block below, but are still
+                  // parseable by name from the shared registry table.
+#define KAGURA_INFRA_PASS(Cli, Ctor)                                           \
+                  if (Name == Cli) {                                           \
+                    MPM.addPass(Ctor);                                         \
+                    return true;                                               \
                   }
-                  if (Name == "kagura-config") {
-                    MPM.addPass(ConfigLoaderPass());
-                    return true;
-                  }
-                  if (Name == "kagura-dwarf-control") {
-                    MPM.addPass(DWARFControlPass());
-                    return true;
-                  }
-                  if (Name == "kagura-symmap") {
-                    MPM.addPass(SymbolMapPass());
-                    return true;
-                  }
-                  if (Name == "kagura-vtp") {
-                    MPM.addPass(VTableProtectionPass());
-                    return true;
-                  }
-                  if (Name == "kagura-audit") {
-                    MPM.addPass(AuditLogPass());
-                    return true;
-                  }
+#include "PassRegistry.def"
                   return false;
                 });
 


### PR DESCRIPTION
## Motivation
The `v0.2.0` registry refactor made `PassRegistry.def` the single source of truth for every pass — except the six **infrastructure passes** (`autoselect`, `config`, `dwarf-control`, `symmap`, `vtp`, `audit`). Their name-parsing was six hand-written blocks in `Plugin.cpp`, identical in shape to what `KAGURA_MOD_PASS` already generates:

```cpp
if (Name == "kagura-vtp") { MPM.addPass(VTableProtectionPass()); return true; }
// ...x6
```

## Change
- Add a `KAGURA_INFRA_PASS(Cli, Ctor)` table to `PassRegistry.def` listing the six infra passes.
- Replace the hand-written `if` blocks in `Plugin.cpp` with a macro include.

Adding an infra pass name is now a one-line registry edit, like every other pass.

## Why the injection stays hand-written
Their `OptimizerLast` injection is intentionally left explicit — each has a bespoke trigger that a uniform bool-flag table cannot express:
- `config` → injected when `!opt::ConfigFile.empty()`
- `dwarf-control` → `opt::DWARFMode != "keep"` (and also in the `-O0` block)
- `symmap` / `vtp` / `audit` → bool flags, but with a **fixed ordering** relative to the obfuscation passes
- `autoselect` → not auto-injected at all

The macro-guard + trailing `#undef` in the `.def` ensure the infra rows expand **only** in the module name-parsing include and remain no-ops in the function-parse and EP-callback includes, so nothing is injected where it shouldn't be.

## Verification
- `opt -passes=kagura-{vtp,symmap,audit,autoselect,dwarf-control,config}` all still parse.
- Full `ctest` suite: **41/41 passed**.