### PR TITLE
feat(windows): run passes via statically linked kagura-opt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,17 +106,79 @@ jobs:
             -DCMAKE_CXX_COMPILER="$env:CLANG_CL" `
             -DLLVM_DIR="$env:LLVM_CMAKE_DIR" `
             -DKAGURA_BUILD_TESTS=ON `
-            -DKAGURA_BITCODE_TOOLS=OFF
+            -DKAGURA_BITCODE_TOOLS=ON
 
       - name: Build
         shell: pwsh
         run: cmake --build build
 
+      # The Windows LLVM tarball sets LLVM_ENABLE_PLUGINS=OFF, so the passes are
+      # linked into kagura-opt and the test suite drives them through that tool.
+      # Until kagura-opt was buildable here this job only proved the sources
+      # compiled — nothing actually ran the passes on Windows.
       - name: Test
         shell: pwsh
         run: |
           cd build
           ctest --output-on-failure
+
+      - name: Smoke test kagura-opt
+        shell: pwsh
+        run: |
+          $opt = "build\bin\kagura-opt.exe"
+          if (-not (Test-Path $opt)) { Write-Error "kagura-opt.exe not built"; exit 1 }
+          & $opt -kagura-fla -S tests\lit\control-flow-flattening.ll -o out.ll
+          if ($LASTEXITCODE -ne 0) { Write-Error "kagura-opt failed"; exit 1 }
+          if (-not (Select-String -Path out.ll -Pattern "switch i32" -Quiet)) {
+            Write-Error "flattening produced no dispatcher switch"; exit 1
+          }
+          Write-Host "kagura-opt OK — flattening dispatcher present"
+
+  # ---- Static-plugin linkage (Windows path, exercised on Linux) ------------
+  # The Windows job above is the only place the static-plugin path runs for
+  # real, and it is the slowest to iterate on.  KAGURA_FORCE_STATIC_PLUGIN
+  # selects the same linkage — passes compiled into a static archive, reached
+  # through kagura-opt's getKaguraPluginInfo() call instead of a loadable
+  # module — on a platform where loadable modules would otherwise be used.
+  # A break in the Windows linkage shows up here first, and cheaply.
+  static-plugin:
+    name: Build & Test (static plugin linkage)
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install LLVM 19
+        run: |
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo add-apt-repository -y "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main"
+          sudo apt-get update
+          sudo apt-get install -y llvm-19-dev clang-19
+
+      - name: Configure
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLLVM_DIR=/usr/lib/llvm-19/lib/cmake/llvm \
+            -DCMAKE_C_COMPILER=clang-19 \
+            -DCMAKE_CXX_COMPILER=clang++-19 \
+            -DKAGURA_FORCE_STATIC_PLUGIN=ON \
+            -DKAGURA_BITCODE_TOOLS=ON \
+            -DKAGURA_BUILD_TESTS=ON
+
+      - name: Build
+        run: cmake --build build -j$(nproc)
+
+      - name: Verify no loadable module was produced
+        run: |
+          if ls build/lib/Transforms/*.so 2>/dev/null; then
+            echo "expected a static archive, found a shared module"; exit 1
+          fi
+          test -f build/lib/Transforms/libKaguraObfuscator.a
+          test -f build/bin/kagura-opt
+
+      - name: Test
+        run: cd build && ctest --output-on-failure -j$(nproc)
 
   # ---- 4.7.4 NDK version matrix (Android cross-compile, Ubuntu) --------
   ndk-matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to Kagura are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **Windows: a working way to run the passes.** `-fpass-plugin` is unavailable
+  on Windows because the MSVC-targeted LLVM ships with
+  `LLVM_ENABLE_PLUGINS=OFF`, and the static `KaguraObfuscator.lib` the build
+  produced there had no consumer — the documented "link it into your driver
+  tool" had no such tool. `kagura-opt` now links the passes in and registers
+  them by calling `getKaguraPluginInfo()` directly, so building with
+  `-DKAGURA_BITCODE_TOOLS=ON` gives Windows users an IR-level entry point.
+- **`KAGURA_FORCE_STATIC_PLUGIN`** — selects the same static-linkage path on
+  macOS and Linux, so the Windows build can be reproduced without a Windows
+  machine. CI runs this configuration on Linux.
+
+### Fixed
+
+- **Windows CI verified nothing.** With no loadable module, the entire test
+  suite short-circuited to a single `echo`, so a green Windows job only meant
+  the sources compiled. The suite now drives the passes through `kagura-opt`
+  on that platform.
+- The static `KaguraObfuscator` archive no longer links the imported LLVM
+  targets. It never needed to resolve those symbols itself, and inheriting
+  their `INTERFACE` include directories as `-isystem` put the macOS SDK C
+  headers ahead of libc++, breaking `<cstddef>`. Consumers link the components
+  (`Core`, `Support`, `Analysis`, `TransformUtils`, `Passes`) instead.
+
 ## [0.2.0] — 2026-06-30
 
 A wide-coverage release. Two new IR passes, three platform attestation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,29 @@ endif()
 option(KAGURA_BITCODE_TOOLS "Build kagura-opt bitcode processing tool" OFF)
 # --------------------------------------------------------------------------
 
+# ---- Plugin linkage mode ----------------------------------------------------
+# LLVM cannot build loadable pass modules everywhere — the MSVC-targeted
+# Windows tarball ships LLVM_ENABLE_PLUGINS=OFF, so `-fpass-plugin` and
+# `opt --load-pass-plugin` are both unavailable there.  On those platforms the
+# passes are built as a static library and linked directly into a driver tool
+# (kagura-opt), which calls getKaguraPluginInfo() instead of dlopen()ing a
+# module.
+#
+# KAGURA_FORCE_STATIC_PLUGIN=ON selects that same path on a host where loadable
+# modules *are* available, so the Windows linkage can be exercised from macOS
+# and Linux CI without a Windows machine.
+option(KAGURA_FORCE_STATIC_PLUGIN
+       "Link the passes statically into kagura-opt even where loadable modules work" OFF)
+
+if(LLVM_ENABLE_PLUGINS AND NOT KAGURA_FORCE_STATIC_PLUGIN)
+  set(KAGURA_PLUGIN_STATIC OFF)
+  message(STATUS "[kagura] Plugin linkage: loadable module (-fpass-plugin)")
+else()
+  set(KAGURA_PLUGIN_STATIC ON)
+  message(STATUS "[kagura] Plugin linkage: static library (link into kagura-opt)")
+endif()
+# --------------------------------------------------------------------------
+
 # Passes (loaded as plugin via -fpass-plugin)
 add_subdirectory(lib)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,39 @@ add_definitions(${LLVM_DEFINITIONS_LIST})
 list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
 include(AddLLVM)
 
+# ---- Windows: prune stale absolute paths from LLVM's exported targets -------
+# The official clang+llvm Windows release bakes absolute paths from the machine
+# that built it into its exported link interfaces — most visibly the DIA SDK's
+# diaguids.lib under a Visual Studio 2019 install that exists nowhere else.
+# Linking anything against those components then fails at generate time with
+# "missing and no known rule to make it", before a single file is compiled.
+#
+# Drop link-interface entries naming an absolute path that does not exist.  If
+# one of them turns out to be genuinely needed, the link fails with an
+# unresolved symbol rather than a confusing missing-file error, and the STATUS
+# line below says exactly what was removed.
+if(WIN32)
+  foreach(_kagura_llvm_target IN LISTS LLVM_AVAILABLE_LIBS)
+    if(NOT TARGET ${_kagura_llvm_target})
+      continue()
+    endif()
+    get_target_property(_kagura_link_libs ${_kagura_llvm_target} INTERFACE_LINK_LIBRARIES)
+    if(NOT _kagura_link_libs)
+      continue()
+    endif()
+    set(_kagura_kept_libs "")
+    foreach(_kagura_lib IN LISTS _kagura_link_libs)
+      if(IS_ABSOLUTE "${_kagura_lib}" AND NOT EXISTS "${_kagura_lib}")
+        message(STATUS "[kagura] ${_kagura_llvm_target}: dropping missing link dependency ${_kagura_lib}")
+      else()
+        list(APPEND _kagura_kept_libs "${_kagura_lib}")
+      endif()
+    endforeach()
+    set_target_properties(${_kagura_llvm_target} PROPERTIES
+      INTERFACE_LINK_LIBRARIES "${_kagura_kept_libs}")
+  endforeach()
+endif()
+
 # Kagura includes
 include_directories(${CMAKE_SOURCE_DIR}/include)
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Built on the **New Pass Manager** (LLVM 17+). Loaded as a pass plugin via `-fpas
 
 **Supported platforms:** iOS · Android · macOS · Windows (MSVC/Clang-CL) · Linux · WebAssembly
 
+> On Windows, `-fpass-plugin` is unavailable (the MSVC-targeted LLVM ships with
+> `LLVM_ENABLE_PLUGINS=OFF`). The passes link statically into `kagura-opt` and run over
+> IR instead — see [Build from Source](docs/getting-started/build-from-source.md).
+
 ## What it protects against
 
 | Threat | Countermeasure |

--- a/docs/getting-started/build-from-source.ja.md
+++ b/docs/getting-started/build-from-source.ja.md
@@ -20,16 +20,43 @@
 
 === "Windows (Clang-CL)"
 
-    `LLVMConfig.cmake` が必要なので、LLVM 開発ツリーが必要です。Windows では Kagura は静的ライブラリ (`KaguraObfuscator.lib`) としてビルドされます。MSVC はロード可能なパスモジュールに対応していないため、静的ライブラリをドライバツールに直接リンクしてください。
+    `LLVMConfig.cmake` が必要なので、LLVM 開発ツリーが必要です。リリースの `clang+llvm-*-x86_64-pc-windows-msvc.tar.xz` を使ってください。`win64.exe` インストーラはバイナリのみで CMake 設定を含みません。
+
+    **Windows では `-fpass-plugin` は動きません。** MSVC 向けの LLVM は `LLVM_ENABLE_PLUGINS=OFF` でビルドされており、clang が開けるロード可能モジュールが存在しないためです。kagura は静的ライブラリとしてビルドされ、`kagura-opt` にリンクされます。`kagura-opt` は `getKaguraPluginInfo()` を直接呼んでパスを登録します。`-DKAGURA_BITCODE_TOOLS=ON` を付けてビルドしてください。
 
     ```bat
     cmake -B build -G Ninja ^
       -DLLVM_DIR=C:\llvm-dev\lib\cmake\llvm ^
       -DCMAKE_C_COMPILER=C:\llvm-dev\bin\clang-cl.exe ^
       -DCMAKE_CXX_COMPILER=C:\llvm-dev\bin\clang-cl.exe ^
+      -DKAGURA_BITCODE_TOOLS=ON ^
       -DKAGURA_BUILD_TESTS=ON
     cmake --build build
     ```
+
+    難読化は clang ドライバ経由ではなく、IR を経由して行います。
+
+    ```bat
+    clang-cl /clang:-emit-llvm /clang:-S app.c -o app.ll
+    build\bin\kagura-opt.exe -kagura-fla -kagura-str -S app.ll -o app.obf.ll
+    clang-cl app.obf.ll /link /out:app.exe
+    ```
+
+    `kagura-opt` を使わず自前のツールにパスをリンクする場合は、エントリポイントを宣言して `PassBuilder` を渡します。`tools/kagura-opt.cpp` が `KAGURA_STATIC_PLUGIN` 有効時に行っているのと同じことです。
+
+    ```cpp
+    // KaguraObfuscator.lib (lib/Transforms/Plugin.cpp) が提供
+    llvm::PassPluginLibraryInfo getKaguraPluginInfo();
+
+    llvm::PassBuilder PB;
+    getKaguraPluginInfo().RegisterPassBuilderCallbacks(PB);
+    ```
+
+    静的アーカイブ自体は LLVM を抱えていないので、`KaguraObfuscator.lib` と一緒にパスが必要とする LLVM コンポーネント (`Core`, `Support`, `Analysis`, `TransformUtils`, `Passes`) もリンクしてください。
+
+!!! note "Windows のリンク方式を他の OS で検証する"
+
+    `-DKAGURA_FORCE_STATIC_PLUGIN=ON` を指定すると、macOS や Linux でも同じ静的リンク経路が選択されます。Windows 実機なしにビルド問題を再現したいときに使えます。CI では Linux でこの構成を回しています。
 
 ## 出力先
 
@@ -37,7 +64,7 @@
 |:-----------------|:--------------|
 | macOS    | `build/lib/Transforms/KaguraObfuscator.dylib` |
 | Linux    | `build/lib/Transforms/KaguraObfuscator.so` |
-| Windows  | `build/lib/Transforms/KaguraObfuscator.lib` (静的) |
+| Windows  | `build/lib/Transforms/KaguraObfuscator.lib` (静的 / `build/bin/kagura-opt.exe` 経由で実行) |
 
 ランタイムライブラリ: `build/runtime/libkagura_runtime.a`
 

--- a/docs/getting-started/build-from-source.md
+++ b/docs/getting-started/build-from-source.md
@@ -20,18 +20,55 @@
 
 === "Windows (Clang-CL)"
 
-    The LLVM dev tree is required for `LLVMConfig.cmake`. Kagura builds as a static
-    library on Windows (`KaguraObfuscator.lib`) since MSVC does not support loadable
-    pass modules — link the static lib directly into your driver tool.
+    The LLVM dev tree is required for `LLVMConfig.cmake`. Download the
+    `clang+llvm-*-x86_64-pc-windows-msvc.tar.xz` release — the `win64.exe`
+    installer is binaries-only and has no CMake config.
+
+    **`-fpass-plugin` does not work on Windows.** The MSVC-targeted LLVM sets
+    `LLVM_ENABLE_PLUGINS=OFF`, so there is no loadable module for clang to
+    open. Kagura instead builds as a static library and is linked into
+    `kagura-opt`, which registers the passes by calling `getKaguraPluginInfo()`
+    directly. Build it with `-DKAGURA_BITCODE_TOOLS=ON`:
 
     ```bat
     cmake -B build -G Ninja ^
       -DLLVM_DIR=C:\llvm-dev\lib\cmake\llvm ^
       -DCMAKE_C_COMPILER=C:\llvm-dev\bin\clang-cl.exe ^
       -DCMAKE_CXX_COMPILER=C:\llvm-dev\bin\clang-cl.exe ^
+      -DKAGURA_BITCODE_TOOLS=ON ^
       -DKAGURA_BUILD_TESTS=ON
     cmake --build build
     ```
+
+    Then obfuscate through IR rather than through the clang driver:
+
+    ```bat
+    clang-cl /clang:-emit-llvm /clang:-S app.c -o app.ll
+    build\bin\kagura-opt.exe -kagura-fla -kagura-str -S app.ll -o app.obf.ll
+    clang-cl app.obf.ll /link /out:app.exe
+    ```
+
+    To link the passes into your own tool instead of using `kagura-opt`,
+    declare the entry point and hand it a `PassBuilder` — this is exactly what
+    `tools/kagura-opt.cpp` does under `KAGURA_STATIC_PLUGIN`:
+
+    ```cpp
+    // Provided by KaguraObfuscator.lib (lib/Transforms/Plugin.cpp)
+    llvm::PassPluginLibraryInfo getKaguraPluginInfo();
+
+    llvm::PassBuilder PB;
+    getKaguraPluginInfo().RegisterPassBuilderCallbacks(PB);
+    ```
+
+    Link `KaguraObfuscator.lib` together with the LLVM components the passes
+    need — `Core`, `Support`, `Analysis`, `TransformUtils`, `Passes` — since the
+    static archive does not carry them itself.
+
+!!! note "Testing the Windows linkage elsewhere"
+
+    `-DKAGURA_FORCE_STATIC_PLUGIN=ON` selects the same static-linkage path on
+    macOS and Linux, which is useful for reproducing a Windows build problem
+    without a Windows machine. CI runs this configuration on Linux.
 
 ## Outputs
 
@@ -39,7 +76,7 @@
 |:---------|:------------|
 | macOS    | `build/lib/Transforms/KaguraObfuscator.dylib` |
 | Linux    | `build/lib/Transforms/KaguraObfuscator.so` |
-| Windows  | `build/lib/Transforms/KaguraObfuscator.lib` (static) |
+| Windows  | `build/lib/Transforms/KaguraObfuscator.lib` (static, run via `build/bin/kagura-opt.exe`) |
 
 Runtime library: `build/runtime/libkagura_runtime.a`
 

--- a/docs/getting-started/requirements.ja.md
+++ b/docs/getting-started/requirements.ja.md
@@ -8,7 +8,7 @@
 
 ## プラットフォームに関する注意
 
-- **Windows** — Clang-CL のみ対応。MSVC はロード可能なパスモジュールに非対応なため、プラグインは静的ライブラリ (`KaguraObfuscator.lib`) としてビルドされます。ドライバツールに直接リンクしてください。
+- **Windows** — Clang-CL のみ対応。かつ `-fpass-plugin` は**使えません**。MSVC 向けの LLVM は `LLVM_ENABLE_PLUGINS=OFF` で配布されているため、`clang -fpass-plugin` も `opt --load-pass-plugin` も kagura をロードできません。パスは静的ライブラリ (`KaguraObfuscator.lib`) としてビルドされ、それをリンクした [`kagura-opt`](build-from-source.md#windows-clang-cl) 経由で実行します。手順は [ソースからビルド](build-from-source.md) を参照してください。
 
 - **WebAssembly** — `kagura-fla` と `kagura-anti-debug` はスキップされます。Wasm は構造化制御フローを要求し、ネイティブのデバッガ面を持たないためです。
 

--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -8,9 +8,12 @@
 
 ## Platform notes
 
-- **Windows** — Clang-CL only. The plugin builds as a static library
-  (`KaguraObfuscator.lib`) because MSVC does not support loadable pass modules.
-  Link it directly into your driver tool.
+- **Windows** — Clang-CL only, and `-fpass-plugin` is **not** available: the
+  MSVC-targeted LLVM ships with `LLVM_ENABLE_PLUGINS=OFF`, so neither
+  `clang -fpass-plugin` nor `opt --load-pass-plugin` can load kagura. The passes
+  build into a static library (`KaguraObfuscator.lib`) and are run through
+  [`kagura-opt`](build-from-source.md#windows-clang-cl) instead, which links
+  them in. See [Build from Source](build-from-source.md) for the workflow.
 
 - **WebAssembly** — `kagura-fla` and `kagura-anti-debug` are skipped because Wasm
   requires structured control flow and has no native debugger surface.

--- a/docs/index.ja.md
+++ b/docs/index.ja.md
@@ -6,6 +6,10 @@ LLVM 17+ の **New Pass Manager** 上に構築。`-fpass-plugin` でパスプラ
 
 **対応プラットフォーム:** iOS · Android · macOS · Windows (MSVC/Clang-CL) · Linux · WebAssembly
 
+!!! warning "Windows は入口が異なります"
+
+    Windows では `-fpass-plugin` は使えません。MSVC 向けの LLVM が `LLVM_ENABLE_PLUGINS=OFF` で配布されており、ロード可能モジュールが存在しないためです。パスは `kagura-opt` に静的リンクされ、IR に対して実行します。詳細は [ソースからビルド](getting-started/build-from-source.md) を参照してください。
+
 !!! tip "はじめての方"
     [**クイックスタート**](getting-started/quick-start.md) からどうぞ。インストールから最初の難読化バイナリまで5分で進めます。
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,13 @@ Built on the **New Pass Manager** (LLVM 17+). Loaded as a pass plugin via `-fpas
 
 **Supported platforms:** iOS · Android · macOS · Windows (MSVC/Clang-CL) · Linux · WebAssembly
 
+!!! warning "Windows uses a different entry point"
+
+    `-fpass-plugin` is unavailable on Windows — the MSVC-targeted LLVM ships with
+    `LLVM_ENABLE_PLUGINS=OFF`, so there is no loadable module. The passes link
+    statically into `kagura-opt` and run over IR instead. See
+    [Build from Source](getting-started/build-from-source.md).
+
 !!! tip "New here?"
     Start with the [**Quick Start**](getting-started/quick-start.md) — five
     minutes from install to your first obfuscated binary.

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -63,7 +63,7 @@ set(KAGURA_SOURCES
   Platform/VMObfuscation.cpp
 )
 
-if(LLVM_ENABLE_PLUGINS)
+if(NOT KAGURA_PLUGIN_STATIC)
   # Normal path: build as a loadable MODULE (macOS .dylib / Linux .so)
   add_llvm_pass_plugin(KaguraObfuscator
     PARTIAL_SOURCES_INTENDED
@@ -74,11 +74,16 @@ else()
   # Fallback for platforms where loadable modules are unsupported (e.g. MSVC).
   # add_llvm_pass_plugin() would create a non-compilable UTILITY target and
   # then abort on subsequent target_* calls.  Build as a static library so
-  # the plugin can be linked directly into a driver tool instead.
-  message(STATUS "[kagura] Loadable modules unavailable — building KaguraObfuscator as STATIC")
+  # the plugin can be linked directly into a driver tool instead — see
+  # tools/kagura-opt.cpp, which calls getKaguraPluginInfo() directly.
   add_library(KaguraObfuscator STATIC ${KAGURA_SOURCES})
   llvm_update_compile_flags(KaguraObfuscator)
-  target_link_libraries(KaguraObfuscator PRIVATE ${LLVM_LIBS})
+  # Deliberately *not* linking ${LLVM_LIBS} here.  A static archive does not
+  # resolve LLVM symbols itself — the final executable does — and depending on
+  # the imported LLVM targets drags their INTERFACE include dirs in as
+  # -isystem, which on macOS puts the SDK C headers ahead of libc++ and breaks
+  # <cstddef>.  The consumer links the components instead; see
+  # tools/CMakeLists.txt (KAGURA_OPT_LLVM_LIBS).
 endif()
 
 target_include_directories(KaguraObfuscator PRIVATE
@@ -94,7 +99,7 @@ endif()
 # ---- Incremental build: precompiled header ----------------------------------
 # PCH is not supported on static libraries in all CMake versions; skip on
 # the fallback static build to keep the Windows build simple.
-if(KAGURA_PCH AND LLVM_ENABLE_PLUGINS)
+if(KAGURA_PCH AND NOT KAGURA_PLUGIN_STATIC)
   target_precompile_headers(KaguraObfuscator PRIVATE
     <llvm/IR/Function.h>
     <llvm/IR/Module.h>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,16 +2,48 @@ find_package(LLVM REQUIRED CONFIG)
 
 # Plugin-based tests (opt --load-pass-plugin) require a loadable module (.so/.dylib/.dll).
 # When LLVM is built without plugin support — e.g. the MSVC-targeted Windows tarball sets
-# LLVM_ENABLE_PLUGINS=OFF — the static .lib cannot be loaded at runtime, so skip all
-# pass tests and register one dummy test so CTest exits 0 rather than "no tests found".
-if(NOT LLVM_ENABLE_PLUGINS)
-  message(STATUS "[kagura] Tests skipped: LLVM_ENABLE_PLUGINS=OFF")
-  message(STATUS "[kagura]   opt --load-pass-plugin requires a DLL, not a static library.")
-  message(STATUS "[kagura]   Build validation is covered by the Build step.")
-  add_test(NAME kagura_static_build_ok
-    COMMAND ${CMAKE_COMMAND} -E echo
-      "Static build OK — plugin tests skipped (LLVM_ENABLE_PLUGINS=OFF)"
-  )
+# LLVM_ENABLE_PLUGINS=OFF — there is no module to load.  The passes are still reachable
+# through kagura-opt, which links them in statically, so run the smoke tests through that
+# tool instead of leaving the platform completely untested.
+if(KAGURA_PLUGIN_STATIC)
+  if(NOT KAGURA_BITCODE_TOOLS)
+    message(STATUS "[kagura] Tests skipped: static plugin build without kagura-opt.")
+    message(STATUS "[kagura]   Configure with -DKAGURA_BITCODE_TOOLS=ON to run pass tests here.")
+    add_test(NAME kagura_static_build_ok
+      COMMAND ${CMAKE_COMMAND} -E echo
+        "Static build OK — pass tests skipped (KAGURA_BITCODE_TOOLS=OFF)"
+    )
+    return()
+  endif()
+
+  message(STATUS "[kagura] Static plugin build — running pass tests via kagura-opt")
+
+  # One pass per test, driven through the statically linked tool.  The marker is
+  # checked against the transformed IR so a silently-inert pass fails the test.
+  macro(kagura_add_tool_test TEST_NAME FLAG INPUT_FILE EXPECT_MARKER)
+    add_test(NAME ${TEST_NAME}
+      COMMAND ${CMAKE_COMMAND}
+        -DKAGURA_OPT=$<TARGET_FILE:kagura-opt>
+        -DFLAG=${FLAG}
+        -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/lit/${INPUT_FILE}
+        -DEXPECT=${EXPECT_MARKER}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/run_tool_test.cmake
+    )
+  endmacro()
+
+  kagura_add_tool_test(test_static_flattening
+    kagura-fla control-flow-flattening.ll "switch i32")
+  kagura_add_tool_test(test_static_string_encryption
+    kagura-str string-encryption.ll "@kagura_enc_")
+  # kagura-opt runs the default -O2 pipeline, which folds this input's opaque
+  # predicates back down, so there is no bogus-CF marker left to match on.  The
+  # assertion here is the weaker "the module survives the pass" — the stronger
+  # structural checks live in the lit suite, which needs a loadable module.
+  kagura_add_tool_test(test_static_bogus_cf
+    kagura-bcf bogus-control-flow.ll "@classify")
+  kagura_add_tool_test(test_static_substitution
+    kagura-sub substitution.ll "define i32 @arith")
+
   return()
 endif()
 

--- a/tests/run_tool_test.cmake
+++ b/tests/run_tool_test.cmake
@@ -1,0 +1,43 @@
+# run_tool_test.cmake — kagura-opt smoke test runner
+# Usage: cmake -DKAGURA_OPT=... -DFLAG=... -DINPUT=... [-DEXPECT=...] -P run_tool_test.cmake
+#
+# Used by static-plugin builds (Windows/MSVC, or KAGURA_FORCE_STATIC_PLUGIN),
+# where `opt --load-pass-plugin` is unavailable and the passes are reached
+# through kagura-opt instead.  Runs one pass over an .ll file and checks the
+# transformed IR for an expected marker.
+
+cmake_minimum_required(VERSION 3.20)
+
+string(RANDOM LENGTH 8 ALPHABET abcdefghijklmnopqrstuvwxyz RAND_SUFFIX)
+set(OUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/kagura_tool_${RAND_SUFFIX}.ll")
+
+execute_process(
+  COMMAND ${KAGURA_OPT} -${FLAG} -S ${INPUT} -o ${OUT_FILE}
+  RESULT_VARIABLE TOOL_RESULT
+  ERROR_VARIABLE TOOL_ERROR
+)
+
+if(NOT TOOL_RESULT EQUAL 0)
+  message(FATAL_ERROR "kagura-opt -${FLAG} failed:\n${TOOL_ERROR}")
+endif()
+
+if(NOT EXISTS ${OUT_FILE})
+  message(FATAL_ERROR "kagura-opt -${FLAG} produced no output file")
+endif()
+
+file(READ ${OUT_FILE} OUT_IR)
+file(REMOVE ${OUT_FILE})
+
+if(OUT_IR STREQUAL "")
+  message(FATAL_ERROR "kagura-opt -${FLAG} produced empty IR")
+endif()
+
+# EXPECT is optional: some passes have no single stable textual marker, and for
+# those reaching a non-empty module without crashing is the assertion.
+if(DEFINED EXPECT AND NOT EXPECT STREQUAL "")
+  string(FIND "${OUT_IR}" "${EXPECT}" FOUND_AT)
+  if(FOUND_AT EQUAL -1)
+    message(FATAL_ERROR
+      "kagura-opt -${FLAG}: expected marker not found in output IR: ${EXPECT}")
+  endif()
+endif()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,13 @@
 # kagura-opt: standalone bitcode processing tool
 #
-# Loads libKaguraObfuscator at runtime via PassPlugin::Load() — no static link
-# against the MODULE.  This avoids the MODULE_LIBRARY linkage restriction.
+# Shared mode (default): loads libKaguraObfuscator at runtime via
+# PassPlugin::Load() — no static link against the MODULE.  This avoids the
+# MODULE_LIBRARY linkage restriction.
+#
+# Static mode (KAGURA_PLUGIN_STATIC): links the passes in and calls
+# getKaguraPluginInfo() directly.  Used where LLVM has no loadable-module
+# support — notably Windows/MSVC, where this tool is the only way to run the
+# passes since -fpass-plugin is unavailable.
 #
 # We use add_llvm_executable (from LLVM's AddLLVM.cmake) instead of plain
 # add_executable so that llvm_update_compile_flags() is applied.  Without it,
@@ -22,6 +28,9 @@ add_llvm_executable(kagura-opt
 if(LLVM_LINK_LLVM_DYLIB)
   set(KAGURA_OPT_LLVM_LIBS LLVM)
 else()
+  # Analysis and TransformUtils are what the passes themselves need: the static
+  # KaguraObfuscator archive does not link LLVM, so the executable has to cover
+  # its dependencies too.
   llvm_map_components_to_libnames(KAGURA_OPT_LLVM_LIBS
     Core
     Support
@@ -29,12 +38,22 @@ else()
     BitWriter
     BitReader
     Passes
+    Analysis
+    TransformUtils
   )
 endif()
 
 target_link_libraries(kagura-opt PRIVATE
   ${KAGURA_OPT_LLVM_LIBS}
 )
+
+# Static mode: link the passes in and switch kagura-opt to the direct
+# getKaguraPluginInfo() call.  KaguraObfuscator must come before the LLVM
+# component libs it depends on, which target_link_libraries already handles.
+if(KAGURA_PLUGIN_STATIC)
+  target_compile_definitions(kagura-opt PRIVATE KAGURA_STATIC_PLUGIN=1)
+  target_link_libraries(kagura-opt PRIVATE KaguraObfuscator)
+endif()
 
 target_include_directories(kagura-opt PRIVATE
   ${CMAKE_SOURCE_DIR}/include

--- a/tools/kagura-opt.cpp
+++ b/tools/kagura-opt.cpp
@@ -25,11 +25,20 @@
 //
 // Implementation note
 // -------------------
-// kagura-opt loads the kagura plugin at runtime via PassPlugin::Load() rather
-// than linking against it statically.  This avoids the MODULE_LIBRARY linkage
-// restriction and header-search-path issues that arise when Plugin.cpp is
-// compiled a second time in a different target.  The plugin path is resolved
-// from the same directory as the kagura-opt executable (build/bin/../lib/).
+// kagura-opt has two linkage modes, selected at configure time:
+//
+//   Shared (default).  The plugin is loaded at runtime via PassPlugin::Load().
+//   This avoids the MODULE_LIBRARY linkage restriction and header-search-path
+//   issues that arise when Plugin.cpp is compiled a second time in a different
+//   target.  The plugin path is resolved from the same directory as the
+//   kagura-opt executable (build/bin/../lib/).
+//
+//   Static (KAGURA_STATIC_PLUGIN).  The passes are linked into this binary and
+//   registered by calling getKaguraPluginInfo() directly.  Required on
+//   platforms where LLVM cannot build loadable modules — notably the
+//   MSVC-targeted Windows toolchain, where LLVM_ENABLE_PLUGINS is OFF and
+//   neither `-fpass-plugin` nor `opt --load-pass-plugin` is available.  On
+//   those platforms kagura-opt is the supported way to run the passes.
 //
 //===----------------------------------------------------------------------===//
 
@@ -59,6 +68,14 @@
 
 using namespace llvm;
 
+#ifdef KAGURA_STATIC_PLUGIN
+// Defined in lib/Transforms/Plugin.cpp, linked in from the static
+// KaguraObfuscator library.  This is the same PassPluginLibraryInfo that
+// llvmGetPassPluginInfo() returns to a dlopen()ing host; calling it directly
+// is what lets the passes run without a loadable module.
+llvm::PassPluginLibraryInfo getKaguraPluginInfo();
+#endif
+
 // ---- CLI options ------------------------------------------------------------
 
 static cl::opt<std::string> InputFilename(
@@ -78,10 +95,14 @@ static cl::opt<char> OptLevel(
 
 static cl::opt<std::string> PluginPath(
     "load-kagura",
-    cl::desc("Path to libKaguraObfuscator plugin (default: auto-detect)"),
+    cl::desc("Path to libKaguraObfuscator plugin (default: auto-detect; "
+             "ignored in static builds)"),
     cl::init(""));
 
 // ---- Plugin path auto-detection ---------------------------------------------
+// Only needed in shared mode; a static build has the passes linked in and
+// never looks for a module on disk.
+#ifndef KAGURA_STATIC_PLUGIN
 
 static std::string getExplicitPluginPath(int argc, char **argv) {
   StringRef Prefix("-load-kagura=");
@@ -136,11 +157,18 @@ static std::string findPlugin(const char *Argv0, StringRef ExplicitPath) {
   return "";
 }
 
+#endif // !KAGURA_STATIC_PLUGIN
+
 // ---- Main -------------------------------------------------------------------
 
 int main(int argc, char **argv) {
   InitLLVM X(argc, argv);
 
+#ifdef KAGURA_STATIC_PLUGIN
+  // The passes are linked into this binary, so there is nothing to load and
+  // the -kagura-* cl::opts are already registered by static initialisation.
+  PassPluginLibraryInfo KaguraInfo = getKaguraPluginInfo();
+#else
   // Load the kagura plugin before parsing command-line options.  The plugin
   // owns the -kagura-* cl::opts, so parsing first would reject those flags as
   // unknown.
@@ -157,9 +185,16 @@ int main(int argc, char **argv) {
                        << toString(PluginOrErr.takeError()) << '\n';
     return 1;
   }
+#endif
 
   cl::ParseCommandLineOptions(argc, argv,
                                "kagura-opt -- apply kagura obfuscation passes\n");
+
+#ifdef KAGURA_STATIC_PLUGIN
+  if (!PluginPath.empty())
+    WithColor::warning() << "-load-kagura is ignored: the passes are linked "
+                            "into this binary.\n";
+#endif
 
   // Load the input module
   LLVMContext Ctx;
@@ -197,7 +232,11 @@ int main(int argc, char **argv) {
 
   // Construct the pass pipeline with the kagura plugin registered.
   PassBuilder PB(nullptr, PipelineTuningOptions(), std::nullopt, &PIC);
+#ifdef KAGURA_STATIC_PLUGIN
+  KaguraInfo.RegisterPassBuilderCallbacks(PB);
+#else
   PluginOrErr->registerPassBuilderCallbacks(PB);
+#endif
 
   PB.registerModuleAnalyses(MAM);
   PB.registerCGSCCAnalyses(CGAM);


### PR DESCRIPTION
## Why

A user asked how to use kagura on Windows ([context](https://github.com/ykus4/kagura/issues)): the guide says the build produces `KaguraObfuscator.lib`, but clang can't load it and `-fpass-plugin` doesn't work there.

They were right, and the gap was bigger than the docs suggested:

- The MSVC-targeted LLVM ships with `LLVM_ENABLE_PLUGINS=OFF`, so neither `clang -fpass-plugin` nor `opt --load-pass-plugin` can load kagura.
- The build fell back to a static `KaguraObfuscator.lib`, and the docs said to "link the static lib directly into your driver tool" — but no such tool existed. `kagura-opt` uses `PassPlugin::Load()`, which is exactly what doesn't work on Windows, and CI built it with `KAGURA_BITCODE_TOOLS=OFF`.
- `tests/CMakeLists.txt` short-circuited the whole suite to a single `echo` when plugins were unavailable. **A green Windows CI run only meant the sources compiled — nothing ever ran the passes on that platform.**

## What changed

- `kagura-opt` gains a static linkage mode (`KAGURA_STATIC_PLUGIN`): it links the passes in and registers them via `getKaguraPluginInfo()` instead of `PassPlugin::Load()`. Windows builds it with `-DKAGURA_BITCODE_TOOLS=ON` and obfuscates through IR.
- `KAGURA_FORCE_STATIC_PLUGIN=ON` selects the same path on macOS/Linux, so the Windows linkage is reproducible without a Windows machine.
- The test suite now drives the passes through `kagura-opt` on static-plugin builds instead of skipping (`tests/run_tool_test.cmake`, 4 tests).
- CI: Windows job builds `kagura-opt` and runs the suite plus a flattening smoke test; a new Linux `static-plugin` job exercises the same linkage cheaply.
- Docs: the Windows sections in `build-from-source`, `requirements`, `index`, and `README` now state that `-fpass-plugin` is unavailable and show the actual workflow (EN + JA).

### Incidental fix

The static archive no longer links the imported LLVM targets. It never resolved those symbols itself, and inheriting their `INTERFACE` include dirs as `-isystem` put the macOS SDK C headers ahead of libc++, breaking `<cstddef>`. Consumers link the components (`Core`, `Support`, `Analysis`, `TransformUtils`, `Passes`) instead.

## Verification

Clean build on macOS (LLVM 22.1.8) with `-DKAGURA_FORCE_STATIC_PLUGIN=ON -DKAGURA_BITCODE_TOOLS=ON`:

- Static archive and `kagura-opt` build; the tool exits 0.
- `-kagura-fla` emits the `switch i32 %kagura.sw.val` dispatcher; `-kagura-str` and `-kagura-sub` transform as expected.
- New static-mode tests: 4/4 pass.
- Default shared mode: no regression (dylib + suite).

**Not yet verified on real Windows** — that's what the CI jobs here are for.

## Known unrelated failure

`regression_vm_large_function` crashes in `VMObfuscationPass::run`. It reproduces identically on unmodified `main`, so it is pre-existing and out of scope for this PR; worth a separate issue.
