### PR TITLE
chore(release): v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Kagura are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.2.1] — 2026-07-31
 
 ### Added
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(kagura VERSION 0.1.0 LANGUAGES CXX C)
+project(kagura VERSION 0.2.1 LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
Release prep for v0.2.1.

- Cuts the `[Unreleased]` CHANGELOG section to `[0.2.1] — 2026-07-31`.
- Bumps `project(kagura VERSION ...)`, which had been left at 0.1.0 since before the v0.2.0 tag.

Contents: the Windows static-linkage work from #50 — `kagura-opt` can now run the passes on Windows, where `-fpass-plugin` is unavailable, and CI exercises that path on a real Windows runner for the first time.