### PR TITLE
ci(docs): give the Pages deploy room to sit in GitHub's queue

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -63,3 +63,8 @@ jobs:
       - name: Deploy
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          # The default is 10 minutes. On 2026-08-06 two consecutive deploys of
+          # 0a11242f sat in deployment_queued for the full 600s and the action
+          # cancelled them, so main shipped nothing while the built site was fine.
+          timeout: 1800000


### PR DESCRIPTION
## Summary

The Pages deploy on `main` has failed twice for `0a11242f` without anything
being wrong with the site. Both attempts created the deployment, reported
`deployment_queued` for exactly 600s, and were then cancelled by
`actions/deploy-pages` when its default timeout expired. This raises that wait
to 30 minutes.

## Type of change

- [x] Build / CI / tooling

## What was ruled out

The build side is clean, so the failure is purely the action giving up:

| Checked | Result |
| --- | --- |
| `mkdocs build --strict` | passes; artefact produced both times |
| Artefact contents | 120 files / 80 dirs, no symlinks, no absolute or `../` paths, only `-rw-r--r--` |
| Artefact size | 1.16 MB, essentially unchanged from the previous green deploy |
| Pages settings | `build_type: workflow`, public, correct `html_url` |
| `github-pages` environment | branch policy allows `main` |
| GitHub Pages status | `operational`, no matching incident |

Timings were identical to the second: 13:33:13 -> 13:43:19 and
13:53:03 -> 14:03:10. Two runs stopping within a second of the same 600s
ceiling means the queue never advanced at all, rather than being merely slow.

## Why this needs a new commit

The Pages deployment id is the commit sha — the logs end with
`Canceled deployment with ID 0a11242f...`, and the payload carries the same
value as `pages_build_version`. Re-running any job on `0a11242f` therefore
reuses the id of the deploy that was already cancelled, so re-running cannot
recover it no matter how fresh the artefact is. Merging this produces a new sha
and a new Pages deployment id.

## Risk

Low; the only effect is how long the deploy step waits. The trade-off is that a
genuinely stuck deploy now occupies a runner for up to 30 minutes instead of 10.

This does not explain why the queue stalled in the first place — that is still
unknown, and the first attempt was the first ever deploy of that sha, so a
poisoned id does not account for it. If a new sha stalls the same way, nothing
repo-side is left to blame and it is worth raising with GitHub Support.

## Test plan

- [x] `docs.yml` parses as valid YAML
- [x] `timeout` is an accepted input — runs already log `timeout: 600000` in the step's `with:` block
- [ ] Docs workflow deploys successfully on the merge commit